### PR TITLE
Fix TypeLib Id runtime error (wasm32)

### DIFF
--- a/src/typelib/id.rs
+++ b/src/typelib/id.rs
@@ -70,9 +70,10 @@ impl TypeLibId {
 
 impl TypeLib {
     pub fn id(&self) -> TypeLibId {
-        let hasher = blake3::Hasher::new_keyed(&LIB_ID_TAG);
-        let engine = StrictWriter::with(usize::MAX, hasher);
+        let mut hasher = blake3::Hasher::new_keyed(&LIB_ID_TAG);
+        let engine = StrictWriter::in_memory(usize::MAX);
         let engine = self.strict_encode(engine).expect("hasher do not error");
-        TypeLibId::from_raw_array(engine.unbox().finalize())
+        hasher.update(&engine.unbox().to_vec());
+        TypeLibId::from_raw_array(hasher.finalize())
     }
 }


### PR DESCRIPTION
For some reason, the generation of the `TypeLibId` causes `RuntimeError: memory access out of bounds` in some browsers.

This PR fixes that problem.

Closes https://github.com/RGB-WG/rgb-wallet/issues/52