### PR TITLE
Update id types (SemId, TypeLibId, TypeSysId)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "baid58"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e9481f083dc44d0cdf1637b8be5db1dee1cb12f6a326a49e001998fa0a3e05"
+checksum = "052064cc0caa02b62c88f06a7237304fb297873c78b6e95addecc3c5ddfce4ae"
 dependencies = [
  "base58",
  "blake3",
@@ -143,9 +143,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake3"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
+checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,13 +107,14 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "baid58"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29eb856caa83b642563396407c1deb5331acd62d9d91cd5a5d0dcab4a825ad4b"
+checksum = "15e9481f083dc44d0cdf1637b8be5db1dee1cb12f6a326a49e001998fa0a3e05"
 dependencies = [
  "base58",
  "blake3",
  "mnemonic",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ required-features = ["base64"]
 amplify = { version = "4.0.0", features = ["apfloat"] }
 strict_encoding = { version = "2.5.0", features = ["derive", "float"] }
 indexmap = "1.9.2"
-baid58 = "0.4.0"
+baid58 = "0.4.1"
 half = "2.2.0"
 sha2 = "0.10.6"
 base64 = { version = "0.21.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ required-features = ["base64"]
 amplify = { version = "4.0.0", features = ["apfloat"] }
 strict_encoding = { version = "2.5.0", features = ["derive", "float"] }
 indexmap = "1.9.2"
-baid58 = "0.3.1"
+baid58 = "0.4.0"
 half = "2.2.0"
 sha2 = "0.10.6"
 base64 = { version = "0.21.0", optional = true }

--- a/src/ast/id.rs
+++ b/src/ast/id.rs
@@ -36,7 +36,7 @@ use crate::{Cls, Ty, TypeRef};
 /// Semantic type id, which commits to the type memory layout, name and field/variant names.
 #[derive(Wrapper, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, From)]
 #[wrapper(Deref, BorrowSlice, Hex, Index, RangeOps)]
-#[display(Self::to_baid58)]
+#[display(Self::to_baid58_string)]
 #[derive(StrictType, StrictEncode, StrictDecode)]
 #[strict_type(lib = STRICT_TYPES_LIB)]
 #[cfg_attr(
@@ -55,13 +55,16 @@ impl Default for SemId {
 }
 
 impl ToBaid58<32> for SemId {
-    const HRI: &'static str = "sty";
+    const HRI: &'static str = "semid";
     fn to_baid58_payload(&self) -> [u8; 32] { self.to_raw_array() }
 }
 impl FromBaid58<32> for SemId {}
 impl FromStr for SemId {
     type Err = Baid58ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> { Self::from_baid58_str(s) }
+}
+impl SemId {
+    fn to_baid58_string(&self) -> String { format!("urn:ubideco:{::<#0}", self.to_baid58()) }
 }
 
 pub const SEM_ID_TAG: [u8; 32] = *b"urn:ubideco:strict-types:typ:v01";

--- a/src/ast/id.rs
+++ b/src/ast/id.rs
@@ -61,7 +61,9 @@ impl ToBaid58<32> for SemId {
 impl FromBaid58<32> for SemId {}
 impl FromStr for SemId {
     type Err = Baid58ParseError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> { Self::from_baid58_str(s) }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_baid58_str(s.trim_start_matches("urn:ubideco:"))
+    }
 }
 impl SemId {
     fn to_baid58_string(&self) -> String { format!("urn:ubideco:{::<#0}", self.to_baid58()) }

--- a/src/stl.rs
+++ b/src/stl.rs
@@ -31,9 +31,9 @@ use crate::{
     TypeSymbol, TypeSysId,
 };
 
-pub const LIB_ID_STD: &str = "justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ";
+pub const LIB_ID_STD: &str = "urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type";
 pub const LIB_ID_STRICT_TYPES: &str =
-    "south_strong_welcome_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby";
+    "urn:ubideco:stl:5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby#south-strong-welcome";
 
 fn _std_sym() -> Result<SymbolicLib, TranspileError> {
     LibBuilder::new(libname!(LIB_NAME_STD), None)

--- a/src/stl.rs
+++ b/src/stl.rs
@@ -31,9 +31,9 @@ use crate::{
     TypeSymbol, TypeSysId,
 };
 
-pub const LIB_ID_STD: &str = "lagoon_rodent_option_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ";
+pub const LIB_ID_STD: &str = "justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ";
 pub const LIB_ID_STRICT_TYPES: &str =
-    "canoe_safari_scholar_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby";
+    "south_strong_welcome_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby";
 
 fn _std_sym() -> Result<SymbolicLib, TranspileError> {
     LibBuilder::new(libname!(LIB_NAME_STD), None)

--- a/src/stl.rs
+++ b/src/stl.rs
@@ -31,7 +31,8 @@ use crate::{
     TypeSymbol, TypeSysId,
 };
 
-pub const LIB_ID_STD: &str = "urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type";
+pub const LIB_ID_STD: &str =
+    "urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type";
 pub const LIB_ID_STRICT_TYPES: &str =
     "urn:ubideco:stl:5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby#south-strong-welcome";
 

--- a/src/typelib/id.rs
+++ b/src/typelib/id.rs
@@ -20,7 +20,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::{Display, Formatter};
+use std::fmt::{Display, self, Formatter};
 use std::str::FromStr;
 
 use amplify::{Bytes32, RawArray};
@@ -67,7 +67,7 @@ impl FromStr for TypeLibId {
     }
 }
 impl Display for TypeLibId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if f.sign_minus() {
             write!(f, "urn:ubideco:{::<}", self.to_baid58())
         } else {

--- a/src/typelib/id.rs
+++ b/src/typelib/id.rs
@@ -20,6 +20,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use amplify::{Bytes32, RawArray};
@@ -35,9 +36,8 @@ use crate::{Dependency, LibRef, SymbolRef, TranspileRef};
 pub const LIB_ID_TAG: [u8; 32] = *b"urn:ubideco:strict-types:lib:v01";
 
 /// Semantic type id, which commits to the type memory layout, name and field/variant names.
-#[derive(Wrapper, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, From)]
+#[derive(Wrapper, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, From)]
 #[wrapper(Deref, BorrowSlice, Hex, Index, RangeOps)]
-#[display(Self::to_baid58_string)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = STRICT_TYPES_LIB)]
 #[cfg_attr(
@@ -66,8 +66,14 @@ impl FromStr for TypeLibId {
         }
     }
 }
-impl TypeLibId {
-    fn to_baid58_string(&self) -> String { format!("urn:ubideco:{::<#0}", self.to_baid58()) }
+impl Display for TypeLibId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if f.sign_minus() {
+            write!(f, "urn:ubideco:{::<}", self.to_baid58())
+        } else {
+            write!(f, "urn:ubideco:{::<#}", self.to_baid58())
+        }
+    }
 }
 
 impl HashId for TypeLibId {

--- a/src/typelib/id.rs
+++ b/src/typelib/id.rs
@@ -20,7 +20,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::{Display, self, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 use amplify::{Bytes32, RawArray};
@@ -59,11 +59,7 @@ impl FromBaid58<32> for TypeLibId {}
 impl FromStr for TypeLibId {
     type Err = Baid58ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with("stl") {
-            Self::from_baid58_str(s)
-        } else {
-            Self::from_baid58_str(&format!("stl:{s}"))
-        }
+        Self::from_baid58_str(s.trim_start_matches("urn:ubideco:"))
     }
 }
 impl Display for TypeLibId {

--- a/src/typelib/id.rs
+++ b/src/typelib/id.rs
@@ -66,9 +66,8 @@ impl FromStr for TypeLibId {
         }
     }
 }
-
 impl TypeLibId {
-    fn to_baid58_string(&self) -> String { format!("{:+}", self.to_baid58()) }
+    fn to_baid58_string(&self) -> String { format!("urn:ubideco:{::<#0}", self.to_baid58()) }
 }
 
 impl HashId for TypeLibId {

--- a/src/typelib/serialize.rs
+++ b/src/typelib/serialize.rs
@@ -145,7 +145,7 @@ impl Display for SymbolicLib {
 
 impl Display for TypeLib {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln!(f, "typelib {} -- {:+}", self.name, self.id())?;
+        writeln!(f, "typelib {} -- {}", self.name, self.id())?;
         writeln!(f)?;
         for dep in &self.dependencies {
             writeln!(f, "{dep} as {}", dep.name)?;
@@ -168,7 +168,7 @@ impl fmt::UpperHex for TypeLib {
         use base64::Engine;
 
         writeln!(f, "-----BEGIN STRICT TYPE LIB-----")?;
-        writeln!(f, "Id: {}", self.id())?;
+        writeln!(f, "Id: {:-}", self.id())?;
         writeln!(f, "Name: {}", self.name)?;
         write!(f, "Dependencies: ")?;
         if self.dependencies.is_empty() {
@@ -178,7 +178,7 @@ impl fmt::UpperHex for TypeLib {
         }
         let mut iter = self.dependencies.iter();
         while let Some(dep) = iter.next() {
-            write!(f, "  {}@{}", dep.name, dep.id)?;
+            write!(f, "  {:-}", dep.id)?;
             if iter.len() > 0 {
                 writeln!(f, ",")?;
             } else {

--- a/src/typesys/id.rs
+++ b/src/typesys/id.rs
@@ -20,6 +20,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::{Display, self, Formatter};
 use std::str::FromStr;
 
 use amplify::{Bytes32, RawArray};
@@ -33,9 +34,8 @@ use crate::TypeSystem;
 
 pub const TYPESYS_ID_TAG: [u8; 32] = *b"urn:ubideco:strict-types:sys:v01";
 
-#[derive(Wrapper, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, From)]
+#[derive(Wrapper, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, From)]
 #[wrapper(Deref, BorrowSlice, Hex, Index, RangeOps)]
-#[display(Self::to_baid58_string)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = STRICT_TYPES_LIB)]
 #[cfg_attr(
@@ -64,9 +64,14 @@ impl FromStr for TypeSysId {
         }
     }
 }
-
-impl TypeSysId {
-    fn to_baid58_string(&self) -> String { format!("{:+}", self.to_baid58()) }
+impl Display for TypeSysId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if f.sign_minus() {
+            write!(f, "urn:ubideco:{::<}", self.to_baid58())
+        } else {
+            write!(f, "urn:ubideco:{::<#}", self.to_baid58())
+        }
+    }
 }
 
 impl HashId for TypeSystem {

--- a/src/typesys/id.rs
+++ b/src/typesys/id.rs
@@ -20,7 +20,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::{Display, self, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 use amplify::{Bytes32, RawArray};
@@ -57,11 +57,7 @@ impl FromBaid58<32> for TypeSysId {}
 impl FromStr for TypeSysId {
     type Err = Baid58ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with("sts") {
-            Self::from_baid58_str(s)
-        } else {
-            Self::from_baid58_str(&format!("sts:{s}"))
-        }
+        Self::from_baid58_str(s.trim_start_matches("urn:ubideco:"))
     }
 }
 impl Display for TypeSysId {

--- a/src/typesys/type_sys.rs
+++ b/src/typesys/type_sys.rs
@@ -135,10 +135,10 @@ impl Index<SemId> for TypeSystem {
 
 impl Display for TypeSystem {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln!(f, "typesys -- {:+}", self.id())?;
+        writeln!(f, "typesys -- {}", self.id())?;
         writeln!(f)?;
         for (id, ty) in &self.0 {
-            writeln!(f, "data {id:0} :: {:0}", ty)?;
+            writeln!(f, "data {id:-} :: {:-}", ty)?;
         }
         Ok(())
     }
@@ -153,7 +153,7 @@ impl fmt::UpperHex for TypeSystem {
         let id = self.id();
 
         writeln!(f, "-----BEGIN STRICT TYPE SYSTEM-----")?;
-        writeln!(f, "Id: {}", id)?;
+        writeln!(f, "Id: {:-}", id)?;
         writeln!(f)?;
 
         let data = self.to_strict_serialized::<U32>().expect("in-memory");

--- a/stl/Std@0.1.0.sta
+++ b/stl/Std@0.1.0.sta
@@ -1,5 +1,5 @@
 -----BEGIN STRICT TYPE LIB-----
-Id: lagoon_rodent_option_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
+Id: justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
 Name: Std
 Dependencies: ~
 

--- a/stl/Std@0.1.0.sta
+++ b/stl/Std@0.1.0.sta
@@ -1,5 +1,5 @@
 -----BEGIN STRICT TYPE LIB-----
-Id: urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type
+Id: urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
 Name: Std
 Dependencies: ~
 

--- a/stl/Std@0.1.0.sta
+++ b/stl/Std@0.1.0.sta
@@ -1,5 +1,5 @@
 -----BEGIN STRICT TYPE LIB-----
-Id: justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
+Id: urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type
 Name: Std
 Dependencies: ~
 

--- a/stl/Std@0.1.0.sty
+++ b/stl/Std@0.1.0.sty
@@ -1,5 +1,5 @@
 {-
-  Id: justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
+  Id: urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type
   Name: Std
   Version: 0.1.0
   Description: Strict types standard library

--- a/stl/Std@0.1.0.sty
+++ b/stl/Std@0.1.0.sty
@@ -1,5 +1,5 @@
 {-
-  Id: lagoon_rodent_option_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
+  Id: justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
   Name: Std
   Version: 0.1.0
   Description: Strict types standard library
@@ -12,7 +12,7 @@ typelib Std
 
 -- no dependencies
 
--- JumpLadderPlato055LGxTk42rZVmuXepF2FJNfP52h3QG5pBnBaY1VnnvnP
+-- JargonRoundBrave055LGxTk42rZVmuXepF2FJNfP52h3QG5pBnBaY1VnnvnP
 data Alpha            :: A:65 | B:66 | C:67 | D:68
                        | E:69 | F:70 | G:71 | H:72
                        | I:73 | J:74 | K:75 | L:76
@@ -27,7 +27,7 @@ data Alpha            :: A:65 | B:66 | C:67 | D:68
                        | s:115 | t:116 | u:117 | v:118
                        | w:119 | x:120 | y:121 | z:122
 
--- MorrisTobaccoAcid043EA5YjDDUMdgMApG3xuUWGSzDXKr6U5b9gtgLwuqCc3
+-- AlbinoRomanOffice043EA5YjDDUMdgMApG3xuUWGSzDXKr6U5b9gtgLwuqCc3
 data AlphaCaps        :: A:65 | B:66 | C:67 | D:68
                        | E:69 | F:70 | G:71 | H:72
                        | I:73 | J:74 | K:75 | L:76
@@ -36,7 +36,7 @@ data AlphaCaps        :: A:65 | B:66 | C:67 | D:68
                        | U:85 | V:86 | W:87 | X:88
                        | Y:89 | Z:90
 
--- CrashLemonNight07U5NvJNf343ZzFXsqW2DBYtTSvrb3YdL6oxYd2BaMsVr
+-- SigmaFocusGround07U5NvJNf343ZzFXsqW2DBYtTSvrb3YdL6oxYd2BaMsVr
 data AlphaCapsNum     :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | A:65 | B:66
@@ -47,7 +47,7 @@ data AlphaCapsNum     :: zero:48 | one:49 | two:50 | three:51
                        | S:83 | T:84 | U:85 | V:86
                        | W:87 | X:88 | Y:89 | Z:90
 
--- OxygenDeliverBrazil0DZX8CtQMz2kGByNeWpSpWzor5EPoeQ1LRsSWcR13w9bH
+-- ImageHermanVillage0DZX8CtQMz2kGByNeWpSpWzor5EPoeQ1LRsSWcR13w9bH
 data AlphaNum         :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | A:65 | B:66
@@ -65,7 +65,7 @@ data AlphaNum         :: zero:48 | one:49 | two:50 | three:51
                        | u:117 | v:118 | w:119 | x:120
                        | y:121 | z:122
 
--- SeniorFlashCycle04UQSpEBq39vFqEBYDaLEMaQ6qJYGDiEFsGFYzv7U7ipA
+-- HenryExceptShoe04UQSpEBq39vFqEBYDaLEMaQ6qJYGDiEFsGFYzv7U7ipA
 data AlphaNumDash     :: dash:45 | zero:48 | one:49 | two:50
                        | three:51 | four:52 | five:53 | six:54
                        | seven:55 | eight:56 | nine:57 | A:65
@@ -83,7 +83,7 @@ data AlphaNumDash     :: dash:45 | zero:48 | one:49 | two:50
                        | t:116 | u:117 | v:118 | w:119
                        | x:120 | y:121 | z:122
 
--- DriverBarbaraRamirez08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz
+-- ShelfJumboCapsule08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz
 data AlphaNumLodash   :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | A:65 | B:66
@@ -101,7 +101,7 @@ data AlphaNumLodash   :: zero:48 | one:49 | two:50 | three:51
                        | t:116 | u:117 | v:118 | w:119
                        | x:120 | y:121 | z:122
 
--- EternalAlbumIgloo0HmLtNhtTNv8cdSDzKcU3p1i3jcJS6TWkrRCw1vYABFJG
+-- KarmaMillionNoise0HmLtNhtTNv8cdSDzKcU3p1i3jcJS6TWkrRCw1vYABFJG
 data AlphaSmall       :: a:97 | b:98 | c:99 | d:100
                        | e:101 | f:102 | g:103 | h:104
                        | i:105 | j:106 | k:107 | l:108
@@ -110,7 +110,7 @@ data AlphaSmall       :: a:97 | b:98 | c:99 | d:100
                        | u:117 | v:118 | w:119 | x:120
                        | y:121 | z:122
 
--- SmilePlasticJudge02NFrhqQqGNDA4HujyTW2pmcjtrN5sbtFfpPFXPPYcGER
+-- CockpitPotatoOcean02NFrhqQqGNDA4HujyTW2pmcjtrN5sbtFfpPFXPPYcGER
 data Ascii            :: nul:0 | soh:1 | stx:2 | etx:3
                        | eot:4 | enq:5 | ack:6 | bel:7
                        | bs:8 | ht:9 | lf:10 | vt:11
@@ -144,7 +144,7 @@ data Ascii            :: nul:0 | soh:1 | stx:2 | etx:3
                        | x:120 | y:121 | z:122 | cBracketL:123
                        | pipe:124 | cBracketR:125 | tilde:126 | del:127
 
--- PierreForbidOrganic0mbH4meZSjxky12xHm9pg3rw8VoGxEa6rXtt6dAMZLbt
+-- MusicJumboFormula0mbH4meZSjxky12xHm9pg3rw8VoGxEa6rXtt6dAMZLbt
 data AsciiPrintable   :: space:32 | excl:33 | quotes:34 | hash:35
                        | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
                        | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
@@ -170,33 +170,33 @@ data AsciiPrintable   :: space:32 | excl:33 | quotes:34 | hash:35
                        | x:120 | y:121 | z:122 | cBracketL:123
                        | pipe:124 | cBracketR:125 | tilde:126
 
--- FashionSharpRodeo07ZhBHGSJm9ixmm8Z9vCX7i5Ga7j5xrW8t11nsb1Cgpnx
+-- ShannonMilanEternal07ZhBHGSJm9ixmm8Z9vCX7i5Ga7j5xrW8t11nsb1Cgpnx
 data Bool             :: false:0 | true:1
 
--- IndiaDiegoMatch0DfVXYs8NyS6G5QLTQMUELHWGkSoenXDw3ZFrHzG3LjMW
+-- AxisDesireExport0DfVXYs8NyS6G5QLTQMUELHWGkSoenXDw3ZFrHzG3LjMW
 data Dec              :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57
 
--- LithiumScarletSource0H5T3iaCVzmGH5BcotfpzcRNb5Z1ri27rwVrRhJ6UosU6
+-- ImitateActionSahara0H5T3iaCVzmGH5BcotfpzcRNb5Z1ri27rwVrRhJ6UosU6
 data HexDecCaps       :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | ten:65 | eleven:66
                        | twelve:67 | thirteen:68 | fourteen:69 | fifteen:70
 
--- GalaxyDeclareFreedom0CBhZBmVRHY5sgou91KEAQrxun6kQQdbCPRekEEoB5Lik
+-- GammaMetroPiano0CBhZBmVRHY5sgou91KEAQrxun6kQQdbCPRekEEoB5Lik
 data HexDecSmall      :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | ten:97 | eleven:98
                        | twelve:99 | thirteen:100 | fourteen:101 | fifteen:102
 
--- CaesarLolaToyota0BrEhDdRPrktqBgsNbgsmUagRz9b5n5csfbmif8Y7Bcc8
+-- MorganGalileoKiwi0BrEhDdRPrktqBgsNbgsmUagRz9b5n5csfbmif8Y7Bcc8
 data U4               :: u4_0:0 | u4_1:1 | u4_2:2 | u4_3:3
                        | u4_4:4 | u4_5:5 | u4_6:6 | u4_7:7
                        | u4_8:8 | u4_9:9 | u4_10:10 | u4_11:11
                        | u4_12:12 | u4_13:13 | u4_14:14 | u4_15:15
 
--- CafeAverageCompass03MDHMYsJt8d1gUiyx5vGCWcNLQ7biek6UTjHg3ksW4Bf
+-- FrontEcologyBronze03MDHMYsJt8d1gUiyx5vGCWcNLQ7biek6UTjHg3ksW4Bf
 data U5               :: u5_0:0 | u5_1:1 | u5_2:2 | u5_3:3
                        | u5_4:4 | u5_5:5 | u5_6:6 | u5_7:7
                        | u5_8:8 | u5_9:9 | u5_10:10 | u5_11:11

--- a/stl/Std@0.1.0.sty
+++ b/stl/Std@0.1.0.sty
@@ -12,7 +12,7 @@ typelib Std
 
 -- no dependencies
 
--- JargonRoundBrave055LGxTk42rZVmuXepF2FJNfP52h3QG5pBnBaY1VnnvnP
+-- urn:ubideco:semid:55LGxTk42rZVmuXepF2FJNfP52h3QG5pBnBaY1VnnvnP#quiet-opinion-saddle
 data Alpha            :: A:65 | B:66 | C:67 | D:68
                        | E:69 | F:70 | G:71 | H:72
                        | I:73 | J:74 | K:75 | L:76
@@ -27,7 +27,7 @@ data Alpha            :: A:65 | B:66 | C:67 | D:68
                        | s:115 | t:116 | u:117 | v:118
                        | w:119 | x:120 | y:121 | z:122
 
--- AlbinoRomanOffice043EA5YjDDUMdgMApG3xuUWGSzDXKr6U5b9gtgLwuqCc3
+-- urn:ubideco:semid:43EA5YjDDUMdgMApG3xuUWGSzDXKr6U5b9gtgLwuqCc3#simon-pegasus-stop
 data AlphaCaps        :: A:65 | B:66 | C:67 | D:68
                        | E:69 | F:70 | G:71 | H:72
                        | I:73 | J:74 | K:75 | L:76
@@ -36,7 +36,7 @@ data AlphaCaps        :: A:65 | B:66 | C:67 | D:68
                        | U:85 | V:86 | W:87 | X:88
                        | Y:89 | Z:90
 
--- SigmaFocusGround07U5NvJNf343ZzFXsqW2DBYtTSvrb3YdL6oxYd2BaMsVr
+-- urn:ubideco:semid:7U5NvJNf343ZzFXsqW2DBYtTSvrb3YdL6oxYd2BaMsVr#magnet-section-latin
 data AlphaCapsNum     :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | A:65 | B:66
@@ -47,7 +47,7 @@ data AlphaCapsNum     :: zero:48 | one:49 | two:50 | three:51
                        | S:83 | T:84 | U:85 | V:86
                        | W:87 | X:88 | Y:89 | Z:90
 
--- ImageHermanVillage0DZX8CtQMz2kGByNeWpSpWzor5EPoeQ1LRsSWcR13w9bH
+-- urn:ubideco:semid:DZX8CtQMz2kGByNeWpSpWzor5EPoeQ1LRsSWcR13w9bH#disco-ibiza-mile
 data AlphaNum         :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | A:65 | B:66
@@ -65,7 +65,7 @@ data AlphaNum         :: zero:48 | one:49 | two:50 | three:51
                        | u:117 | v:118 | w:119 | x:120
                        | y:121 | z:122
 
--- HenryExceptShoe04UQSpEBq39vFqEBYDaLEMaQ6qJYGDiEFsGFYzv7U7ipA
+-- urn:ubideco:semid:4UQSpEBq39vFqEBYDaLEMaQ6qJYGDiEFsGFYzv7U7ipA#good-trumpet-today
 data AlphaNumDash     :: dash:45 | zero:48 | one:49 | two:50
                        | three:51 | four:52 | five:53 | six:54
                        | seven:55 | eight:56 | nine:57 | A:65
@@ -83,7 +83,7 @@ data AlphaNumDash     :: dash:45 | zero:48 | one:49 | two:50
                        | t:116 | u:117 | v:118 | w:119
                        | x:120 | y:121 | z:122
 
--- ShelfJumboCapsule08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz
+-- urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa
 data AlphaNumLodash   :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | A:65 | B:66
@@ -101,7 +101,7 @@ data AlphaNumLodash   :: zero:48 | one:49 | two:50 | three:51
                        | t:116 | u:117 | v:118 | w:119
                        | x:120 | y:121 | z:122
 
--- KarmaMillionNoise0HmLtNhtTNv8cdSDzKcU3p1i3jcJS6TWkrRCw1vYABFJG
+-- urn:ubideco:semid:HmLtNhtTNv8cdSDzKcU3p1i3jcJS6TWkrRCw1vYABFJG#song-accent-mammal
 data AlphaSmall       :: a:97 | b:98 | c:99 | d:100
                        | e:101 | f:102 | g:103 | h:104
                        | i:105 | j:106 | k:107 | l:108
@@ -110,7 +110,7 @@ data AlphaSmall       :: a:97 | b:98 | c:99 | d:100
                        | u:117 | v:118 | w:119 | x:120
                        | y:121 | z:122
 
--- CockpitPotatoOcean02NFrhqQqGNDA4HujyTW2pmcjtrN5sbtFfpPFXPPYcGER
+-- urn:ubideco:semid:2NFrhqQqGNDA4HujyTW2pmcjtrN5sbtFfpPFXPPYcGER#aloha-lunar-felix
 data Ascii            :: nul:0 | soh:1 | stx:2 | etx:3
                        | eot:4 | enq:5 | ack:6 | bel:7
                        | bs:8 | ht:9 | lf:10 | vt:11
@@ -144,7 +144,7 @@ data Ascii            :: nul:0 | soh:1 | stx:2 | etx:3
                        | x:120 | y:121 | z:122 | cBracketL:123
                        | pipe:124 | cBracketR:125 | tilde:126 | del:127
 
--- MusicJumboFormula0mbH4meZSjxky12xHm9pg3rw8VoGxEa6rXtt6dAMZLbt
+-- urn:ubideco:semid:mbH4meZSjxky12xHm9pg3rw8VoGxEa6rXtt6dAMZLbt#diet-oxford-window
 data AsciiPrintable   :: space:32 | excl:33 | quotes:34 | hash:35
                        | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
                        | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
@@ -170,33 +170,33 @@ data AsciiPrintable   :: space:32 | excl:33 | quotes:34 | hash:35
                        | x:120 | y:121 | z:122 | cBracketL:123
                        | pipe:124 | cBracketR:125 | tilde:126
 
--- ShannonMilanEternal07ZhBHGSJm9ixmm8Z9vCX7i5Ga7j5xrW8t11nsb1Cgpnx
+-- urn:ubideco:semid:7ZhBHGSJm9ixmm8Z9vCX7i5Ga7j5xrW8t11nsb1Cgpnx#laser-madam-maxwell
 data Bool             :: false:0 | true:1
 
--- AxisDesireExport0DfVXYs8NyS6G5QLTQMUELHWGkSoenXDw3ZFrHzG3LjMW
+-- urn:ubideco:semid:DfVXYs8NyS6G5QLTQMUELHWGkSoenXDw3ZFrHzG3LjMW#amanda-spider-diamond
 data Dec              :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57
 
--- ImitateActionSahara0H5T3iaCVzmGH5BcotfpzcRNb5Z1ri27rwVrRhJ6UosU6
+-- urn:ubideco:semid:H5T3iaCVzmGH5BcotfpzcRNb5Z1ri27rwVrRhJ6UosU6#invest-moral-anvil
 data HexDecCaps       :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | ten:65 | eleven:66
                        | twelve:67 | thirteen:68 | fourteen:69 | fifteen:70
 
--- GammaMetroPiano0CBhZBmVRHY5sgou91KEAQrxun6kQQdbCPRekEEoB5Lik
+-- urn:ubideco:semid:CBhZBmVRHY5sgou91KEAQrxun6kQQdbCPRekEEoB5Lik#forum-sahara-email
 data HexDecSmall      :: zero:48 | one:49 | two:50 | three:51
                        | four:52 | five:53 | six:54 | seven:55
                        | eight:56 | nine:57 | ten:97 | eleven:98
                        | twelve:99 | thirteen:100 | fourteen:101 | fifteen:102
 
--- MorganGalileoKiwi0BrEhDdRPrktqBgsNbgsmUagRz9b5n5csfbmif8Y7Bcc8
+-- urn:ubideco:semid:BrEhDdRPrktqBgsNbgsmUagRz9b5n5csfbmif8Y7Bcc8#east-invest-harvest
 data U4               :: u4_0:0 | u4_1:1 | u4_2:2 | u4_3:3
                        | u4_4:4 | u4_5:5 | u4_6:6 | u4_7:7
                        | u4_8:8 | u4_9:9 | u4_10:10 | u4_11:11
                        | u4_12:12 | u4_13:13 | u4_14:14 | u4_15:15
 
--- FrontEcologyBronze03MDHMYsJt8d1gUiyx5vGCWcNLQ7biek6UTjHg3ksW4Bf
+-- urn:ubideco:semid:3MDHMYsJt8d1gUiyx5vGCWcNLQ7biek6UTjHg3ksW4Bf#ground-volume-singer
 data U5               :: u5_0:0 | u5_1:1 | u5_2:2 | u5_3:3
                        | u5_4:4 | u5_5:5 | u5_6:6 | u5_7:7
                        | u5_8:8 | u5_9:9 | u5_10:10 | u5_11:11

--- a/stl/StrictTypes@0.1.0.sta
+++ b/stl/StrictTypes@0.1.0.sta
@@ -1,8 +1,8 @@
 -----BEGIN STRICT TYPE LIB-----
-Id: canoe_safari_scholar_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby
+Id: south_strong_welcome_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby
 Name: StrictTypes
 Dependencies: 
-  Std@lagoon_rodent_option_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
+  Std@justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
 
 C1N0cmljdFR5cGVzAXuEgDye+uIRJad8LDm8cNL96PlDrg39nPTmgu3HZspwA1N0
 ZAEDU3RkAQByjqaKl950IPYqWWmwS4cmBL9F1t84lZx+JuenJJDkrQ5BbHBoYU51

--- a/stl/StrictTypes@0.1.0.sta
+++ b/stl/StrictTypes@0.1.0.sta
@@ -1,8 +1,8 @@
 -----BEGIN STRICT TYPE LIB-----
-Id: south_strong_welcome_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby
+Id: urn:ubideco:stl:5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby#south-strong-welcome
 Name: StrictTypes
 Dependencies: 
-  Std@justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
+  Std@urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type
 
 C1N0cmljdFR5cGVzAXuEgDye+uIRJad8LDm8cNL96PlDrg39nPTmgu3HZspwA1N0
 ZAEDU3RkAQByjqaKl950IPYqWWmwS4cmBL9F1t84lZx+JuenJJDkrQ5BbHBoYU51

--- a/stl/StrictTypes@0.1.0.sta
+++ b/stl/StrictTypes@0.1.0.sta
@@ -1,8 +1,8 @@
 -----BEGIN STRICT TYPE LIB-----
-Id: urn:ubideco:stl:5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby#south-strong-welcome
+Id: urn:ubideco:stl:5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby
 Name: StrictTypes
 Dependencies: 
-  Std@urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type
+  urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ
 
 C1N0cmljdFR5cGVzAXuEgDye+uIRJad8LDm8cNL96PlDrg39nPTmgu3HZspwA1N0
 ZAEDU3RkAQByjqaKl950IPYqWWmwS4cmBL9F1t84lZx+JuenJJDkrQ5BbHBoYU51

--- a/stl/StrictTypes@0.1.0.sty
+++ b/stl/StrictTypes@0.1.0.sty
@@ -1,5 +1,5 @@
 {-
-  Id: canoe_safari_scholar_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby
+  Id: south_strong_welcome_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby
   Name: StrictTypes
   Version: 0.1.0
   Description: Confined generalized algebraic data types (GADT)
@@ -10,75 +10,75 @@
 
 typelib StrictTypes
 
-import lagoon_rodent_option_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ as Std
+import justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ as Std
 -- Imports:
--- AlphaNumLodash := DriverBarbaraRamirez08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz
+-- AlphaNumLodash := ShelfJumboCapsule08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz
 
 
 
--- NeverBrokenSaturn0FV6aCKqTnAc6kavvC48U6WEjAqc4H6UTi2iRTxFrhqPY
+-- ChaosConceptLucas0FV6aCKqTnAc6kavvC48U6WEjAqc4H6UTi2iRTxFrhqPY
 data Dependency       :: id TypeLibId, name LibName
--- VeronaDieselMango051iuuNfXdzE8dx9Y9QEaiGP2cc7yJzirY4abawBKNGE6
+-- DetectIgorTable051iuuNfXdzE8dx9Y9QEaiGP2cc7yJzirY4abawBKNGE6
 data EnumVariants     :: {Variant ^ 1..0xff}
--- LeonidMarvinSilence029hz6aMnfcGz3SEVoUv6k5PfZjSPJX7bJpiQj3EKkGwx
+-- JungleSiliconVisa029hz6aMnfcGz3SEVoUv6k5PfZjSPJX7bJpiQj3EKkGwx
 data ExternRef        :: libId TypeLibId, semId SemId
--- MedusaAdmiralUnique02GJ4sjfUm59XEr5Hrcn9hdA9zD9VhHuyjtErnrpH6vEs
+-- AmandaBorisFirst02GJ4sjfUm59XEr5Hrcn9hdA9zD9VhHuyjtErnrpH6vEs
 data FieldInlineRef   :: name FieldName, ty InlineRef
--- TogaAdmiralAcid04cYyU4JWGoY76byD4PYLwNsHTrbRiic5PbUDpSQMFYih
+-- ChinaColorRadius04cYyU4JWGoY76byD4PYLwNsHTrbRiic5PbUDpSQMFYih
 data FieldInlineRef1  :: name FieldName, ty InlineRef1
--- EuropeIrisAmber05tdhprRvkZVPGAqkYuZT1RmsccSgfg5mz1ohgXH32PLy
+-- ZebraRiverPicture05tdhprRvkZVPGAqkYuZT1RmsccSgfg5mz1ohgXH32PLy
 data FieldInlineRef2  :: name FieldName, ty InlineRef2
--- MedusaFluidJazz04NgjiSuLr3txVBAtRWe9t68GiwigifkCB5hzTqo7fQSj
+-- ChickenTractorFloat04NgjiSuLr3txVBAtRWe9t68GiwigifkCB5hzTqo7fQSj
 data FieldLibRef      :: name FieldName, ty LibRef
--- HistorySponsorJimmy0EXf9yMeW9dZv4Aq4kPcWAgG1pmBDaLKzV6fMqMxckeWK
+-- CrackPerformScorpio0EXf9yMeW9dZv4Aq4kPcWAgG1pmBDaLKzV6fMqMxckeWK
 data FieldName        :: Ident
--- TouristTommyElectra08yQQNsKP7MtL4dVP7dJNXnGutLdhs5xdmx369dp18pea
+-- MoralResumeTrapeze08yQQNsKP7MtL4dVP7dJNXnGutLdhs5xdmx369dp18pea
 data FieldSemId       :: name FieldName, ty SemId
--- AlgebraVisitorUltra09SkVki7nQ7WRGN2ayWjySv7QSh6ftrakdNRbE2sSbUYw
-data Ident            :: [Std.AlphaNumLodash {- DriverBarbaraRamirez08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz -} ^ 1..0x64]
--- BruceStingCantina0ACXJeMFxSCfKaDXpGZzzDJ9PZrnWERenBSkaVgmqztT9
+-- ColaMonacoRomeo09SkVki7nQ7WRGN2ayWjySv7QSh6ftrakdNRbE2sSbUYw
+data Ident            :: [Std.AlphaNumLodash {- ShelfJumboCapsule08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz -} ^ 1..0x64]
+-- SundayJacobLegend0ACXJeMFxSCfKaDXpGZzzDJ9PZrnWERenBSkaVgmqztT9
 data InlineRef        :: inline TyInlineRef1
                        | named SemId
                        | extern ExternRef
--- RalphJosephPackage0GuvQNNvNkmUT8fJYCXuucUCFSRqoHoy4g2wB54PgnP5D
+-- JungleFamousMuseum0GuvQNNvNkmUT8fJYCXuucUCFSRqoHoy4g2wB54PgnP5D
 data InlineRef1       :: inline TyInlineRef2
                        | named SemId
                        | extern ExternRef
--- LegacyDominicArena09VXzdXS3wF1eomrLkmhKMK9kTdVQnWQUW5Fhqbm3E4Ux
+-- BritishStampStory09VXzdXS3wF1eomrLkmhKMK9kTdVQnWQUW5Fhqbm3E4Ux
 data InlineRef2       :: named SemId
                        | extern ExternRef
--- ChickenSundayVanilla0CfGN6VgrTXVEvMF4TVu9vihmn9YEwHFck9GM26Gwfn7k
+-- FilmMentorCorner0CfGN6VgrTXVEvMF4TVu9vihmn9YEwHFck9GM26Gwfn7k
 data LibName          :: Ident
--- NorwayEngineApple0HKxXPz1j5bUNYzAyyHE5qghcffX5nUEfJWDP2hSdWyGC
+-- AztecMemoEnrico0HKxXPz1j5bUNYzAyyHE5qghcffX5nUEfJWDP2hSdWyGC
 data LibRef           :: inline TyInlineRef
                        | named SemId
                        | extern ExternRef
--- BottleBenefitSweden094DUadJMLRjBzGtu4sbzw4m1515nWSZSoRBRX6zx94RT
+-- ExtremeAbsorbFortune094DUadJMLRjBzGtu4sbzw4m1515nWSZSoRBRX6zx94RT
 data NamedFieldsInlineRef :: [FieldInlineRef ^ 1..0xff]
--- EarthNuclearTobacco0FTnqX46y9MLGSmSBaVTYWr5KNB43SiJDgM98eeyE1uEf
+-- SloganWhiskeyDetail0FTnqX46y9MLGSmSBaVTYWr5KNB43SiJDgM98eeyE1uEf
 data NamedFieldsInlineRef1 :: [FieldInlineRef1 ^ 1..0xff]
--- OthelloInsidePhantom0A56U8yCFhAKvocfRD2mbE9YemfE5iDQVwygBXeWgA1Hx
+-- ModelNumberPromo0A56U8yCFhAKvocfRD2mbE9YemfE5iDQVwygBXeWgA1Hx
 data NamedFieldsInlineRef2 :: [FieldInlineRef2 ^ 1..0xff]
--- KiloOlympicIsabel0EDuAn1A4guy6TkgtgKcLksuHPz1AWNxYQRyw1bkXrpGv
+-- BuffaloMonitorTwist0EDuAn1A4guy6TkgtgKcLksuHPz1AWNxYQRyw1bkXrpGv
 data NamedFieldsLibRef :: [FieldLibRef ^ 1..0xff]
--- FlexVocalDenver07MoLEA46Roi1ELw5DcLEqNhxVJYJ4z2hN1yQHX4RVMFa
+-- GeniusHazardAlpha07MoLEA46Roi1ELw5DcLEqNhxVJYJ4z2hN1yQHX4RVMFa
 data NamedFieldsSemId :: [FieldSemId ^ 1..0xff]
--- NoisePierreFrance03T3zMmQxuir7TsdjhBLaETJfLH4mr5amAseXDePnzhMT
+-- ShampooNerveVisa03T3zMmQxuir7TsdjhBLaETJfLH4mr5amAseXDePnzhMT
 data Primitive        :: U8
--- StandMailboxBaboon08Ckj2p3GLKina636pSKJkj7GB6ft8XeoP4jfGkRUNwtp
+-- PodiumNadiaAurora08Ckj2p3GLKina636pSKJkj7GB6ft8XeoP4jfGkRUNwtp
 data SemId            :: [Byte ^ 32]
--- CairoEverestScreen09jnMbAs5A91zjK9KDrLuFH42WtinmB8GY6JE6BMY31hw
+-- KarateMachineSeason09jnMbAs5A91zjK9KDrLuFH42WtinmB8GY6JE6BMY31hw
 data Sizing           :: min U64, max U64
--- XrayDialogTopic0HTSFwsgZjYXJRLbgpT4NXrqn81U1epqjZAJf7Lf4XLT1
+-- BarcodeBeatlesBurma0HTSFwsgZjYXJRLbgpT4NXrqn81U1epqjZAJf7Lf4XLT1
 data SymbolRef        :: libName LibName
                        , tyName TypeName
                        , libId TypeLibId
                        , semId SemId
--- UrgentGateAnalyze0CatmbYRFh9sq96VaCNZDoxwPSs3QA6U9z8g5mXy5JyeD
+-- HenryInviteWindow0CatmbYRFh9sq96VaCNZDoxwPSs3QA6U9z8g5mXy5JyeD
 data SymbolicSys      :: symbols Symbols, types TypeSystem
--- EternalRichardCopy03YfnJ7fXxmtKqtNg6bUGo9ac8vdwUpqib8R6nGPiJJLF
+-- NelsonNextSilk03YfnJ7fXxmtKqtNg6bUGo9ac8vdwUpqib8R6nGPiJJLF
 data Symbols          :: libs {Dependency}, symbols {TypeSymbol ^ ..0xffffff}
--- IvanTorpedoCenter08DRwuKzTL4Le1SS1ZqsRAKXSf5vEeH4GZpBP7C47KQLZ
+-- HarlemJanetBlitz08DRwuKzTL4Le1SS1ZqsRAKXSf5vEeH4GZpBP7C47KQLZ
 data TyInlineRef      :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -89,7 +89,7 @@ data TyInlineRef      :: primitive Primitive
                        | list (InlineRef, Sizing)
                        | set (InlineRef, Sizing)
                        | map (InlineRef, InlineRef, Sizing)
--- ShallowGorillaPluto08uSo7Y1LqX6RZXB9n4B3ckMpVSUXSgBcVe4NDQFcFkFN
+-- AppearVendorApril08uSo7Y1LqX6RZXB9n4B3ckMpVSUXSgBcVe4NDQFcFkFN
 data TyInlineRef1     :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -100,7 +100,7 @@ data TyInlineRef1     :: primitive Primitive
                        | list (InlineRef1, Sizing)
                        | set (InlineRef1, Sizing)
                        | map (InlineRef1, InlineRef1, Sizing)
--- ControlArchiveCecilia08Zao2AsxACSZEghypLLtvZe2UELita7DpVS7sQTqcvod
+-- TogaHumorTravel08Zao2AsxACSZEghypLLtvZe2UELita7DpVS7sQTqcvod
 data TyInlineRef2     :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -111,7 +111,7 @@ data TyInlineRef2     :: primitive Primitive
                        | list (InlineRef2, Sizing)
                        | set (InlineRef2, Sizing)
                        | map (InlineRef2, InlineRef2, Sizing)
--- OpinionZipperPaper08Ph3m9aiAfvjV6kHYXBAaK9PeyfGyBgU387PspxCDupQ
+-- GoodSummerPump08Ph3m9aiAfvjV6kHYXBAaK9PeyfGyBgU387PspxCDupQ
 data TyLibRef         :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -122,7 +122,7 @@ data TyLibRef         :: primitive Primitive
                        | list (LibRef, Sizing)
                        | set (LibRef, Sizing)
                        | map (LibRef, LibRef, Sizing)
--- SampleAustinStrong05umsZQXgcipmGCn8h2TTged2CDuaSDoDJQzW3BkTr4aK
+-- PepperNeptuneKermit05umsZQXgcipmGCn8h2TTged2CDuaSDoDJQzW3BkTr4aK
 data TySemId          :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -133,53 +133,53 @@ data TySemId          :: primitive Primitive
                        | list (SemId, Sizing)
                        | set (SemId, Sizing)
                        | map (SemId, SemId, Sizing)
--- ServiceDemoMission0AbBubPzzwg8DYXHoASLchKS9KLUQmnX15TPHzuSTenxF
+-- RecyclePlaceMartin0AbBubPzzwg8DYXHoASLchKS9KLUQmnX15TPHzuSTenxF
 data TypeFqn          :: lib LibName, name TypeName
--- TrinityGeminiPerform02qdbDrCxa4pUbo5gUmu4P8b4ja8v3UVJqv4thcekvaZr
+-- PhoneConceptSting02qdbDrCxa4pUbo5gUmu4P8b4ja8v3UVJqv4thcekvaZr
 data TypeLib          :: name LibName
                        , dependencies {Dependency ^ ..0xff}
                        , externTypes {LibName -> ^ ..0xff {SemId -> TypeName}}
                        , types {TypeName -> ^ 1.. TyLibRef}
--- IronSpainMulti0DENrVJmXwRSwiZez8ZgUBsvQkTBTKy86zADExJ68bcaq
+-- DilemmaGarboBison0DENrVJmXwRSwiZez8ZgUBsvQkTBTKy86zADExJ68bcaq
 data TypeLibId        :: [Byte ^ 32]
--- OwnerMemphisToronto0BeAZU9i8ViQp3kbm2kXTVTchqzybypmhcFNG7yr1mi39
+-- AnalogTrumpetExpand0BeAZU9i8ViQp3kbm2kXTVTchqzybypmhcFNG7yr1mi39
 data TypeName         :: Ident
--- BritishEternalGraph02mWV4gJf12MJKJ93AsXmXqocLkwndHW79NS1G2xoZrpy
+-- AlbumGrilleGustav02mWV4gJf12MJKJ93AsXmXqocLkwndHW79NS1G2xoZrpy
 data TypeSymbol       :: id SemId, fqn TypeFqn?
--- ScrollTelecomMedia046cvynAxpvUUTPvrCDQARcmwHHETLhkcgy8345mN1LLq
+-- SalonNorwayOrder046cvynAxpvUUTPvrCDQARcmwHHETLhkcgy8345mN1LLq
 data TypeSysId        :: [Byte ^ 32]
--- LotusSuperContour0A3dqfyLgVP7VBHEeYPKkBvAtouxNvKS2EFNYeKXsN2iy
+-- AtlasComplexTaxi0A3dqfyLgVP7VBHEeYPKkBvAtouxNvKS2EFNYeKXsN2iy
 data TypeSystem       :: {SemId -> ^ ..0xffffff TySemId}
--- NixonEnigmaClark06AWJKZiwinJPiiidywfDKCLnkYMzy1mQNU46q9AqLrRj
+-- AvalonLegacyRavioli06AWJKZiwinJPiiidywfDKCLnkYMzy1mQNU46q9AqLrRj
 data UnionVariantsInlineRef :: {U8 -> ^ ..0xff VariantInfoInlineRef}
--- PatternSonarAlbert0B38wGtyv8gja4Z1RgX4BYSkwLg2SWNfWoHy6Lm74ZFGA
+-- JessicaChromeScratch0B38wGtyv8gja4Z1RgX4BYSkwLg2SWNfWoHy6Lm74ZFGA
 data UnionVariantsInlineRef1 :: {U8 -> ^ ..0xff VariantInfoInlineRef1}
--- JuliusPercentCharlie07wf6GJPBgC6NKeB1JfK9W72ZDNkPFfd6C2R19FiL5Yn8
+-- VerbalSchoolFish07wf6GJPBgC6NKeB1JfK9W72ZDNkPFfd6C2R19FiL5Yn8
 data UnionVariantsInlineRef2 :: {U8 -> ^ ..0xff VariantInfoInlineRef2}
--- CakeCitrusNumber0zPC3EHHjZnDwJGNih8rYV52sjgfpNrpZz2eZey47d28
+-- StyleMadamBikini0zPC3EHHjZnDwJGNih8rYV52sjgfpNrpZz2eZey47d28
 data UnionVariantsLibRef :: {U8 -> ^ ..0xff VariantInfoLibRef}
--- EclipseRobotPrepare0DkkFcBhrhogm6ACVw48aLr9FJ2mMy5Pi6nySsobbrBb5
+-- BonusZoomMadonna0DkkFcBhrhogm6ACVw48aLr9FJ2mMy5Pi6nySsobbrBb5
 data UnionVariantsSemId :: {U8 -> ^ ..0xff VariantInfoSemId}
--- SwingForestJazz079HiyC2Lm1dFG4ZcaeyfLT94RjnteSmkRkcReVdMzTM4
+-- CadetAlfonsoSheriff079HiyC2Lm1dFG4ZcaeyfLT94RjnteSmkRkcReVdMzTM4
 data UnnamedFieldsInlineRef :: [InlineRef ^ 1..0xff]
--- BurmaHeliumHeart0udGXz59QaShngQ467mwGx42uto92AQbvR2gQyZM3ihb
+-- EdgarAirlineSample0udGXz59QaShngQ467mwGx42uto92AQbvR2gQyZM3ihb
 data UnnamedFieldsInlineRef1 :: [InlineRef1 ^ 1..0xff]
--- SegmentShallowJoker04P9ySyD5yTC9pVRkiRENje4ub4E2avLiQuB1hbUNWgYx
+-- SoundGlobalBoris04P9ySyD5yTC9pVRkiRENje4ub4E2avLiQuB1hbUNWgYx
 data UnnamedFieldsInlineRef2 :: [InlineRef2 ^ 1..0xff]
--- RobinLakeDriver04CvGjQBATcDfDMPF2QNu8vej45ehRatkwRm7LK5MZ7MK
+-- StretchGalleryTulip04CvGjQBATcDfDMPF2QNu8vej45ehRatkwRm7LK5MZ7MK
 data UnnamedFieldsLibRef :: [LibRef ^ 1..0xff]
--- OfficeSleepResult0AHCYFYAtpW2kxJpVpmD6suNB9epMm6zffaDMtotKcXvh
+-- VideoMysteryBlock0AHCYFYAtpW2kxJpVpmD6suNB9epMm6zffaDMtotKcXvh
 data UnnamedFieldsSemId :: [SemId ^ 1..0xff]
--- WeatherHistoryKinetic0BPoLofDtYzh8rRxa2ss4SxWc9VsuF6wtfVNqbdstcrXf
+-- ProtectAlphaMeteor0BPoLofDtYzh8rRxa2ss4SxWc9VsuF6wtfVNqbdstcrXf
 data Variant          :: name FieldName, tag U8
--- BambinoCarpetPoetic0Cy1X8nRdwM4yHmaSZ3ahiuBdsAe3RbNp6oR56LCzagx9
+-- SuperBrazilCouple0Cy1X8nRdwM4yHmaSZ3ahiuBdsAe3RbNp6oR56LCzagx9
 data VariantInfoInlineRef :: name FieldName, ty InlineRef
--- BonjourStatusMango0FQoVf49AYi7SWk5zAKMA6tttgCDPBzRTcdmBogEdUkz9
+-- FloridaBonusSuzuki0FQoVf49AYi7SWk5zAKMA6tttgCDPBzRTcdmBogEdUkz9
 data VariantInfoInlineRef1 :: name FieldName, ty InlineRef1
--- StreetTigerTibet08y3bWbWqemKa5z8AQ6yUFizMuZ9FQbtZjXw5LeKsipvq
+-- VillageHabitatRound08y3bWbWqemKa5z8AQ6yUFizMuZ9FQbtZjXw5LeKsipvq
 data VariantInfoInlineRef2 :: name FieldName, ty InlineRef2
--- VocalDiagramGround0ByNU4fSLr6cr9YYjyNf6ja3ErMnKeQYPtWmyZy1YHCq8
+-- PumpDavidBruce0ByNU4fSLr6cr9YYjyNf6ja3ErMnKeQYPtWmyZy1YHCq8
 data VariantInfoLibRef :: name FieldName, ty LibRef
--- FerrariRoverSection08QSJ14SZzimY7RGYUaH9w71kAgxLjECPAs9x84sk28uu
+-- GenevaCarbonFruit08QSJ14SZzimY7RGYUaH9w71kAgxLjECPAs9x84sk28uu
 data VariantInfoSemId :: name FieldName, ty SemId
 

--- a/stl/StrictTypes@0.1.0.sty
+++ b/stl/StrictTypes@0.1.0.sty
@@ -12,73 +12,73 @@ typelib StrictTypes
 
 import justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ as Std
 -- Imports:
--- AlphaNumLodash := ShelfJumboCapsule08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz
+-- AlphaNumLodash := urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa
 
 
 
--- ChaosConceptLucas0FV6aCKqTnAc6kavvC48U6WEjAqc4H6UTi2iRTxFrhqPY
+-- urn:ubideco:semid:FV6aCKqTnAc6kavvC48U6WEjAqc4H6UTi2iRTxFrhqPY#silence-tommy-direct
 data Dependency       :: id TypeLibId, name LibName
--- DetectIgorTable051iuuNfXdzE8dx9Y9QEaiGP2cc7yJzirY4abawBKNGE6
+-- urn:ubideco:semid:51iuuNfXdzE8dx9Y9QEaiGP2cc7yJzirY4abawBKNGE6#karate-sister-aztec
 data EnumVariants     :: {Variant ^ 1..0xff}
--- JungleSiliconVisa029hz6aMnfcGz3SEVoUv6k5PfZjSPJX7bJpiQj3EKkGwx
+-- urn:ubideco:semid:29hz6aMnfcGz3SEVoUv6k5PfZjSPJX7bJpiQj3EKkGwx#ritual-soprano-scholar
 data ExternRef        :: libId TypeLibId, semId SemId
--- AmandaBorisFirst02GJ4sjfUm59XEr5Hrcn9hdA9zD9VhHuyjtErnrpH6vEs
+-- urn:ubideco:semid:2GJ4sjfUm59XEr5Hrcn9hdA9zD9VhHuyjtErnrpH6vEs#phoenix-poker-amanda
 data FieldInlineRef   :: name FieldName, ty InlineRef
--- ChinaColorRadius04cYyU4JWGoY76byD4PYLwNsHTrbRiic5PbUDpSQMFYih
+-- urn:ubideco:semid:4cYyU4JWGoY76byD4PYLwNsHTrbRiic5PbUDpSQMFYih#pedro-cement-crown
 data FieldInlineRef1  :: name FieldName, ty InlineRef1
--- ZebraRiverPicture05tdhprRvkZVPGAqkYuZT1RmsccSgfg5mz1ohgXH32PLy
+-- urn:ubideco:semid:5tdhprRvkZVPGAqkYuZT1RmsccSgfg5mz1ohgXH32PLy#serpent-natasha-freddie
 data FieldInlineRef2  :: name FieldName, ty InlineRef2
--- ChickenTractorFloat04NgjiSuLr3txVBAtRWe9t68GiwigifkCB5hzTqo7fQSj
+-- urn:ubideco:semid:4NgjiSuLr3txVBAtRWe9t68GiwigifkCB5hzTqo7fQSj#stone-horizon-protect
 data FieldLibRef      :: name FieldName, ty LibRef
--- CrackPerformScorpio0EXf9yMeW9dZv4Aq4kPcWAgG1pmBDaLKzV6fMqMxckeWK
+-- urn:ubideco:semid:EXf9yMeW9dZv4Aq4kPcWAgG1pmBDaLKzV6fMqMxckeWK#today-green-neptune
 data FieldName        :: Ident
--- MoralResumeTrapeze08yQQNsKP7MtL4dVP7dJNXnGutLdhs5xdmx369dp18pea
+-- urn:ubideco:semid:8yQQNsKP7MtL4dVP7dJNXnGutLdhs5xdmx369dp18pea#storm-vega-pegasus
 data FieldSemId       :: name FieldName, ty SemId
--- ColaMonacoRomeo09SkVki7nQ7WRGN2ayWjySv7QSh6ftrakdNRbE2sSbUYw
-data Ident            :: [Std.AlphaNumLodash {- ShelfJumboCapsule08iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz -} ^ 1..0x64]
--- SundayJacobLegend0ACXJeMFxSCfKaDXpGZzzDJ9PZrnWERenBSkaVgmqztT9
+-- urn:ubideco:semid:9SkVki7nQ7WRGN2ayWjySv7QSh6ftrakdNRbE2sSbUYw#connect-fragile-exile
+data Ident            :: [Std.AlphaNumLodash {- urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa -} ^ 1..0x64]
+-- urn:ubideco:semid:ACXJeMFxSCfKaDXpGZzzDJ9PZrnWERenBSkaVgmqztT9#magnet-llama-drum
 data InlineRef        :: inline TyInlineRef1
                        | named SemId
                        | extern ExternRef
--- JungleFamousMuseum0GuvQNNvNkmUT8fJYCXuucUCFSRqoHoy4g2wB54PgnP5D
+-- urn:ubideco:semid:GuvQNNvNkmUT8fJYCXuucUCFSRqoHoy4g2wB54PgnP5D#ramirez-break-ribbon
 data InlineRef1       :: inline TyInlineRef2
                        | named SemId
                        | extern ExternRef
--- BritishStampStory09VXzdXS3wF1eomrLkmhKMK9kTdVQnWQUW5Fhqbm3E4Ux
+-- urn:ubideco:semid:9VXzdXS3wF1eomrLkmhKMK9kTdVQnWQUW5Fhqbm3E4Ux#gong-tunnel-lexicon
 data InlineRef2       :: named SemId
                        | extern ExternRef
--- FilmMentorCorner0CfGN6VgrTXVEvMF4TVu9vihmn9YEwHFck9GM26Gwfn7k
+-- urn:ubideco:semid:CfGN6VgrTXVEvMF4TVu9vihmn9YEwHFck9GM26Gwfn7k#public-pagoda-bonjour
 data LibName          :: Ident
--- AztecMemoEnrico0HKxXPz1j5bUNYzAyyHE5qghcffX5nUEfJWDP2hSdWyGC
+-- urn:ubideco:semid:HKxXPz1j5bUNYzAyyHE5qghcffX5nUEfJWDP2hSdWyGC#focus-vitamin-plate
 data LibRef           :: inline TyInlineRef
                        | named SemId
                        | extern ExternRef
--- ExtremeAbsorbFortune094DUadJMLRjBzGtu4sbzw4m1515nWSZSoRBRX6zx94RT
+-- urn:ubideco:semid:94DUadJMLRjBzGtu4sbzw4m1515nWSZSoRBRX6zx94RT#arthur-shelter-bermuda
 data NamedFieldsInlineRef :: [FieldInlineRef ^ 1..0xff]
--- SloganWhiskeyDetail0FTnqX46y9MLGSmSBaVTYWr5KNB43SiJDgM98eeyE1uEf
+-- urn:ubideco:semid:FTnqX46y9MLGSmSBaVTYWr5KNB43SiJDgM98eeyE1uEf#zebra-stone-river
 data NamedFieldsInlineRef1 :: [FieldInlineRef1 ^ 1..0xff]
--- ModelNumberPromo0A56U8yCFhAKvocfRD2mbE9YemfE5iDQVwygBXeWgA1Hx
+-- urn:ubideco:semid:A56U8yCFhAKvocfRD2mbE9YemfE5iDQVwygBXeWgA1Hx#java-paper-maze
 data NamedFieldsInlineRef2 :: [FieldInlineRef2 ^ 1..0xff]
--- BuffaloMonitorTwist0EDuAn1A4guy6TkgtgKcLksuHPz1AWNxYQRyw1bkXrpGv
+-- urn:ubideco:semid:EDuAn1A4guy6TkgtgKcLksuHPz1AWNxYQRyw1bkXrpGv#silicon-average-gong
 data NamedFieldsLibRef :: [FieldLibRef ^ 1..0xff]
--- GeniusHazardAlpha07MoLEA46Roi1ELw5DcLEqNhxVJYJ4z2hN1yQHX4RVMFa
+-- urn:ubideco:semid:7MoLEA46Roi1ELw5DcLEqNhxVJYJ4z2hN1yQHX4RVMFa#local-english-sonata
 data NamedFieldsSemId :: [FieldSemId ^ 1..0xff]
--- ShampooNerveVisa03T3zMmQxuir7TsdjhBLaETJfLH4mr5amAseXDePnzhMT
+-- urn:ubideco:semid:3T3zMmQxuir7TsdjhBLaETJfLH4mr5amAseXDePnzhMT#hobby-cable-puzzle
 data Primitive        :: U8
--- PodiumNadiaAurora08Ckj2p3GLKina636pSKJkj7GB6ft8XeoP4jfGkRUNwtp
+-- urn:ubideco:semid:8Ckj2p3GLKina636pSKJkj7GB6ft8XeoP4jfGkRUNwtp#cargo-plasma-catalog
 data SemId            :: [Byte ^ 32]
--- KarateMachineSeason09jnMbAs5A91zjK9KDrLuFH42WtinmB8GY6JE6BMY31hw
+-- urn:ubideco:semid:9jnMbAs5A91zjK9KDrLuFH42WtinmB8GY6JE6BMY31hw#canoe-gordon-amazon
 data Sizing           :: min U64, max U64
--- BarcodeBeatlesBurma0HTSFwsgZjYXJRLbgpT4NXrqn81U1epqjZAJf7Lf4XLT1
+-- urn:ubideco:semid:HTSFwsgZjYXJRLbgpT4NXrqn81U1epqjZAJf7Lf4XLT1#pocket-oxford-monster
 data SymbolRef        :: libName LibName
                        , tyName TypeName
                        , libId TypeLibId
                        , semId SemId
--- HenryInviteWindow0CatmbYRFh9sq96VaCNZDoxwPSs3QA6U9z8g5mXy5JyeD
+-- urn:ubideco:semid:CatmbYRFh9sq96VaCNZDoxwPSs3QA6U9z8g5mXy5JyeD#diagram-crimson-blast
 data SymbolicSys      :: symbols Symbols, types TypeSystem
--- NelsonNextSilk03YfnJ7fXxmtKqtNg6bUGo9ac8vdwUpqib8R6nGPiJJLF
+-- urn:ubideco:semid:3YfnJ7fXxmtKqtNg6bUGo9ac8vdwUpqib8R6nGPiJJLF#shock-castle-robin
 data Symbols          :: libs {Dependency}, symbols {TypeSymbol ^ ..0xffffff}
--- HarlemJanetBlitz08DRwuKzTL4Le1SS1ZqsRAKXSf5vEeH4GZpBP7C47KQLZ
+-- urn:ubideco:semid:8DRwuKzTL4Le1SS1ZqsRAKXSf5vEeH4GZpBP7C47KQLZ#absent-logo-genius
 data TyInlineRef      :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -89,7 +89,7 @@ data TyInlineRef      :: primitive Primitive
                        | list (InlineRef, Sizing)
                        | set (InlineRef, Sizing)
                        | map (InlineRef, InlineRef, Sizing)
--- AppearVendorApril08uSo7Y1LqX6RZXB9n4B3ckMpVSUXSgBcVe4NDQFcFkFN
+-- urn:ubideco:semid:8uSo7Y1LqX6RZXB9n4B3ckMpVSUXSgBcVe4NDQFcFkFN#taxi-rhino-secret
 data TyInlineRef1     :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -100,7 +100,7 @@ data TyInlineRef1     :: primitive Primitive
                        | list (InlineRef1, Sizing)
                        | set (InlineRef1, Sizing)
                        | map (InlineRef1, InlineRef1, Sizing)
--- TogaHumorTravel08Zao2AsxACSZEghypLLtvZe2UELita7DpVS7sQTqcvod
+-- urn:ubideco:semid:8Zao2AsxACSZEghypLLtvZe2UELita7DpVS7sQTqcvod#pacific-dolby-result
 data TyInlineRef2     :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -111,7 +111,7 @@ data TyInlineRef2     :: primitive Primitive
                        | list (InlineRef2, Sizing)
                        | set (InlineRef2, Sizing)
                        | map (InlineRef2, InlineRef2, Sizing)
--- GoodSummerPump08Ph3m9aiAfvjV6kHYXBAaK9PeyfGyBgU387PspxCDupQ
+-- urn:ubideco:semid:8Ph3m9aiAfvjV6kHYXBAaK9PeyfGyBgU387PspxCDupQ#russian-sweden-period
 data TyLibRef         :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -122,7 +122,7 @@ data TyLibRef         :: primitive Primitive
                        | list (LibRef, Sizing)
                        | set (LibRef, Sizing)
                        | map (LibRef, LibRef, Sizing)
--- PepperNeptuneKermit05umsZQXgcipmGCn8h2TTged2CDuaSDoDJQzW3BkTr4aK
+-- urn:ubideco:semid:5umsZQXgcipmGCn8h2TTged2CDuaSDoDJQzW3BkTr4aK#solo-canal-flower
 data TySemId          :: primitive Primitive
                        | unicode ()
                        | enum:3 EnumVariants
@@ -133,53 +133,53 @@ data TySemId          :: primitive Primitive
                        | list (SemId, Sizing)
                        | set (SemId, Sizing)
                        | map (SemId, SemId, Sizing)
--- RecyclePlaceMartin0AbBubPzzwg8DYXHoASLchKS9KLUQmnX15TPHzuSTenxF
+-- urn:ubideco:semid:AbBubPzzwg8DYXHoASLchKS9KLUQmnX15TPHzuSTenxF#salary-apollo-chicago
 data TypeFqn          :: lib LibName, name TypeName
--- PhoneConceptSting02qdbDrCxa4pUbo5gUmu4P8b4ja8v3UVJqv4thcekvaZr
+-- urn:ubideco:semid:2qdbDrCxa4pUbo5gUmu4P8b4ja8v3UVJqv4thcekvaZr#gallery-coral-actor
 data TypeLib          :: name LibName
                        , dependencies {Dependency ^ ..0xff}
                        , externTypes {LibName -> ^ ..0xff {SemId -> TypeName}}
                        , types {TypeName -> ^ 1.. TyLibRef}
--- DilemmaGarboBison0DENrVJmXwRSwiZez8ZgUBsvQkTBTKy86zADExJ68bcaq
+-- urn:ubideco:semid:DENrVJmXwRSwiZez8ZgUBsvQkTBTKy86zADExJ68bcaq#jessica-snake-ceramic
 data TypeLibId        :: [Byte ^ 32]
--- AnalogTrumpetExpand0BeAZU9i8ViQp3kbm2kXTVTchqzybypmhcFNG7yr1mi39
+-- urn:ubideco:semid:BeAZU9i8ViQp3kbm2kXTVTchqzybypmhcFNG7yr1mi39#vega-shock-state
 data TypeName         :: Ident
--- AlbumGrilleGustav02mWV4gJf12MJKJ93AsXmXqocLkwndHW79NS1G2xoZrpy
+-- urn:ubideco:semid:2mWV4gJf12MJKJ93AsXmXqocLkwndHW79NS1G2xoZrpy#match-alaska-fragile
 data TypeSymbol       :: id SemId, fqn TypeFqn?
--- SalonNorwayOrder046cvynAxpvUUTPvrCDQARcmwHHETLhkcgy8345mN1LLq
+-- urn:ubideco:semid:46cvynAxpvUUTPvrCDQARcmwHHETLhkcgy8345mN1LLq#clara-tonight-office
 data TypeSysId        :: [Byte ^ 32]
--- AtlasComplexTaxi0A3dqfyLgVP7VBHEeYPKkBvAtouxNvKS2EFNYeKXsN2iy
+-- urn:ubideco:semid:A3dqfyLgVP7VBHEeYPKkBvAtouxNvKS2EFNYeKXsN2iy#system-marco-torpedo
 data TypeSystem       :: {SemId -> ^ ..0xffffff TySemId}
--- AvalonLegacyRavioli06AWJKZiwinJPiiidywfDKCLnkYMzy1mQNU46q9AqLrRj
+-- urn:ubideco:semid:6AWJKZiwinJPiiidywfDKCLnkYMzy1mQNU46q9AqLrRj#sonar-voodoo-change
 data UnionVariantsInlineRef :: {U8 -> ^ ..0xff VariantInfoInlineRef}
--- JessicaChromeScratch0B38wGtyv8gja4Z1RgX4BYSkwLg2SWNfWoHy6Lm74ZFGA
+-- urn:ubideco:semid:B38wGtyv8gja4Z1RgX4BYSkwLg2SWNfWoHy6Lm74ZFGA#japan-hope-monster
 data UnionVariantsInlineRef1 :: {U8 -> ^ ..0xff VariantInfoInlineRef1}
--- VerbalSchoolFish07wf6GJPBgC6NKeB1JfK9W72ZDNkPFfd6C2R19FiL5Yn8
+-- urn:ubideco:semid:7wf6GJPBgC6NKeB1JfK9W72ZDNkPFfd6C2R19FiL5Yn8#stage-secret-bonus
 data UnionVariantsInlineRef2 :: {U8 -> ^ ..0xff VariantInfoInlineRef2}
--- StyleMadamBikini0zPC3EHHjZnDwJGNih8rYV52sjgfpNrpZz2eZey47d28
+-- urn:ubideco:semid:zPC3EHHjZnDwJGNih8rYV52sjgfpNrpZz2eZey47d28#violet-mailbox-kimono
 data UnionVariantsLibRef :: {U8 -> ^ ..0xff VariantInfoLibRef}
--- BonusZoomMadonna0DkkFcBhrhogm6ACVw48aLr9FJ2mMy5Pi6nySsobbrBb5
+-- urn:ubideco:semid:DkkFcBhrhogm6ACVw48aLr9FJ2mMy5Pi6nySsobbrBb5#sponsor-lotus-pretend
 data UnionVariantsSemId :: {U8 -> ^ ..0xff VariantInfoSemId}
--- CadetAlfonsoSheriff079HiyC2Lm1dFG4ZcaeyfLT94RjnteSmkRkcReVdMzTM4
+-- urn:ubideco:semid:79HiyC2Lm1dFG4ZcaeyfLT94RjnteSmkRkcReVdMzTM4#silk-mega-loyal
 data UnnamedFieldsInlineRef :: [InlineRef ^ 1..0xff]
--- EdgarAirlineSample0udGXz59QaShngQ467mwGx42uto92AQbvR2gQyZM3ihb
+-- urn:ubideco:semid:udGXz59QaShngQ467mwGx42uto92AQbvR2gQyZM3ihb#rabbit-burma-geneva
 data UnnamedFieldsInlineRef1 :: [InlineRef1 ^ 1..0xff]
--- SoundGlobalBoris04P9ySyD5yTC9pVRkiRENje4ub4E2avLiQuB1hbUNWgYx
+-- urn:ubideco:semid:4P9ySyD5yTC9pVRkiRENje4ub4E2avLiQuB1hbUNWgYx#fashion-april-special
 data UnnamedFieldsInlineRef2 :: [InlineRef2 ^ 1..0xff]
--- StretchGalleryTulip04CvGjQBATcDfDMPF2QNu8vej45ehRatkwRm7LK5MZ7MK
+-- urn:ubideco:semid:4CvGjQBATcDfDMPF2QNu8vej45ehRatkwRm7LK5MZ7MK#poetic-century-ozone
 data UnnamedFieldsLibRef :: [LibRef ^ 1..0xff]
--- VideoMysteryBlock0AHCYFYAtpW2kxJpVpmD6suNB9epMm6zffaDMtotKcXvh
+-- urn:ubideco:semid:AHCYFYAtpW2kxJpVpmD6suNB9epMm6zffaDMtotKcXvh#signal-satire-russian
 data UnnamedFieldsSemId :: [SemId ^ 1..0xff]
--- ProtectAlphaMeteor0BPoLofDtYzh8rRxa2ss4SxWc9VsuF6wtfVNqbdstcrXf
+-- urn:ubideco:semid:BPoLofDtYzh8rRxa2ss4SxWc9VsuF6wtfVNqbdstcrXf#sabrina-stage-harmony
 data Variant          :: name FieldName, tag U8
--- SuperBrazilCouple0Cy1X8nRdwM4yHmaSZ3ahiuBdsAe3RbNp6oR56LCzagx9
+-- urn:ubideco:semid:Cy1X8nRdwM4yHmaSZ3ahiuBdsAe3RbNp6oR56LCzagx9#speech-fractal-cable
 data VariantInfoInlineRef :: name FieldName, ty InlineRef
--- FloridaBonusSuzuki0FQoVf49AYi7SWk5zAKMA6tttgCDPBzRTcdmBogEdUkz9
+-- urn:ubideco:semid:FQoVf49AYi7SWk5zAKMA6tttgCDPBzRTcdmBogEdUkz9#avalon-ozone-clinic
 data VariantInfoInlineRef1 :: name FieldName, ty InlineRef1
--- VillageHabitatRound08y3bWbWqemKa5z8AQ6yUFizMuZ9FQbtZjXw5LeKsipvq
+-- urn:ubideco:semid:8y3bWbWqemKa5z8AQ6yUFizMuZ9FQbtZjXw5LeKsipvq#equal-flood-crater
 data VariantInfoInlineRef2 :: name FieldName, ty InlineRef2
--- PumpDavidBruce0ByNU4fSLr6cr9YYjyNf6ja3ErMnKeQYPtWmyZy1YHCq8
+-- urn:ubideco:semid:ByNU4fSLr6cr9YYjyNf6ja3ErMnKeQYPtWmyZy1YHCq8#process-empire-observe
 data VariantInfoLibRef :: name FieldName, ty LibRef
--- GenevaCarbonFruit08QSJ14SZzimY7RGYUaH9w71kAgxLjECPAs9x84sk28uu
+-- urn:ubideco:semid:8QSJ14SZzimY7RGYUaH9w71kAgxLjECPAs9x84sk28uu#labor-south-newton
 data VariantInfoSemId :: name FieldName, ty SemId
 

--- a/stl/StrictTypes@0.1.0.sty
+++ b/stl/StrictTypes@0.1.0.sty
@@ -1,5 +1,5 @@
 {-
-  Id: south_strong_welcome_5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby
+  Id: urn:ubideco:stl:5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby#south-strong-welcome
   Name: StrictTypes
   Version: 0.1.0
   Description: Confined generalized algebraic data types (GADT)
@@ -10,7 +10,7 @@
 
 typelib StrictTypes
 
-import justice_rocket_type_9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ as Std
+import urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type as Std
 -- Imports:
 -- AlphaNumLodash := urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa
 


### PR DESCRIPTION
- use new Baid58 v0.4 with strengthened checksum
- require HRI presence
- use URN format for ids
- skip checksums in certain contexts