### PR TITLE
Do not commit to the type name in SemId

### DIFF
--- a/src/ast/id.rs
+++ b/src/ast/id.rs
@@ -52,7 +52,7 @@ pub struct SemId(
 );
 
 impl Default for SemId {
-    fn default() -> Self { Ty::<SemId>::UNIT.sem_id_unnamed() }
+    fn default() -> Self { Ty::<SemId>::UNIT.id(false) }
 }
 
 impl ToBaid58<32> for SemId {
@@ -80,23 +80,21 @@ pub const SEM_ID_TAG: [u8; 32] = *b"urn:ubideco:strict-types:typ:v01";
 
 impl TypeRef for SemId {
     fn is_unicode_char(&self) -> bool { Self::unicode_char() == *self }
-    fn is_byte(&self) -> bool { Self::byte() == *self || Ty::<Self>::U8.sem_id_unnamed() == *self }
+    fn is_byte(&self) -> bool { Self::byte() == *self || Ty::<Self>::U8.id(false) == *self }
 }
 
 impl PrimitiveRef for SemId {
-    fn byte() -> Self { Ty::<Self>::BYTE.sem_id_unnamed() }
-    fn unicode_char() -> Self { Ty::<Self>::UNICODE.sem_id_unnamed() }
+    fn byte() -> Self { Ty::<Self>::BYTE.id(false) }
+    fn unicode_char() -> Self { Ty::<Self>::UNICODE.id(false) }
 }
 
 impl<Ref: TypeRef> Ty<Ref> {
-    fn sem_id_inner(&self, name: Option<&TypeName>) -> SemId {
+    pub fn id(&self, named: bool) -> SemId {
         let tag = sha2::Sha256::new_with_prefix(SEM_ID_TAG).finalize();
         let mut hasher = sha2::Sha256::new();
         hasher.commit_consume(tag);
         hasher.commit_consume(tag);
-        if let Some(name) = name {
-            name.sem_commit(&mut hasher);
-        }
+        hasher.commit_consume(&[named as u8]);
         self.sem_commit(&mut hasher);
         SemId::from_byte_array(hasher.finalize())
     }

--- a/src/stl.rs
+++ b/src/stl.rs
@@ -32,9 +32,9 @@ use crate::{
 };
 
 pub const LIB_ID_STD: &str =
-    "urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rocket-type";
+    "urn:ubideco:stl:DvfhVzvEhGDRH4SqHeHCZazYtga1iTd5gMRjeKcREqyy#evident-solo-master";
 pub const LIB_ID_STRICT_TYPES: &str =
-    "urn:ubideco:stl:5XLKQ1sNryZm9bdFKU2kBY3MPYdZXhchVdQKBbHA3gby#south-strong-welcome";
+    "urn:ubideco:stl:E2crdJVDeAf23qaEsg3U36m1b6ScRwJAVLaMkh3Pzik9#serial-linda-extend";
 
 fn _std_sym() -> Result<SymbolicLib, TranspileError> {
     LibBuilder::new(libname!(LIB_NAME_STD), None)

--- a/src/typelib/id.rs
+++ b/src/typelib/id.rs
@@ -86,8 +86,8 @@ impl SemCommit for TypeLib {
             dep.sem_commit(hasher);
         }
         hasher.commit_consume(self.types.len_u16().to_le_bytes());
-        for (name, ty) in &self.types {
-            let sem_id = ty.sem_id_named(name);
+        for ty in self.types.values() {
+            let sem_id = ty.id(true);
             sem_id.sem_commit(hasher);
         }
     }

--- a/src/typelib/serialize.rs
+++ b/src/typelib/serialize.rs
@@ -134,7 +134,7 @@ impl Display for SymbolicLib {
         writeln!(f)?;
         for (name, ty) in self.types() {
             if f.alternate() {
-                writeln!(f, "-- {:0}", ty.sem_id_named(name))?;
+                writeln!(f, "-- {:0}", ty.id(true))?;
             }
             write!(f, "data {name:0$} : ", f.width().unwrap_or(16))?;
             Display::fmt(ty, f)?;

--- a/src/typelib/symbolic.rs
+++ b/src/typelib/symbolic.rs
@@ -278,7 +278,7 @@ impl SymbolicLib {
                 index = ctx.index;
                 extern_types = ctx.extern_types;
                 found = true;
-                let id = ty.sem_id_named(name);
+                let id = ty.id(true);
                 index.insert(name.clone(), id);
                 new_types.insert(name.clone(), ty);
                 old_types.remove(name);
@@ -318,7 +318,7 @@ impl TypeLib {
     pub fn to_symbolic(&self) -> Result<SymbolicLib, SymbolError> {
         let lib_index = self.dependencies.iter().map(|dep| (dep.id, dep.name.clone())).collect();
         let reverse_index =
-            self.types.iter().map(|(name, ty)| (ty.sem_id_named(name), name.clone())).collect();
+            self.types.iter().map(|(name, ty)| (ty.id(true), name.clone())).collect();
         let ctx = SymbolContext {
             reverse_index,
             lib_index,

--- a/src/typelib/transpile.rs
+++ b/src/typelib/transpile.rs
@@ -225,7 +225,7 @@ impl BuilderParent for LibBuilder {
                 TranspileRef::Named(name)
             }
             (lib, Some(name)) => {
-                let id = ty.sem_id_named(&name);
+                let id = ty.id(true);
                 self.extern_types.entry(lib.clone()).or_default().insert(id, name.clone());
                 let lib_id = self.dependency_id(&lib);
                 TranspileRef::Extern(SymbolRef::with(lib, name, lib_id, id))

--- a/src/typesys/translate.rs
+++ b/src/typesys/translate.rs
@@ -105,9 +105,9 @@ impl SystemBuilder {
             .extend(lib.dependencies.into_iter().filter(|dep| !self.imported_deps.contains(dep)));
 
         for (ty_name, ty) in lib.types {
-            let id = ty.sem_id_named(&ty_name);
+            let id = ty.id(true);
             let ty = ty.translate(&mut self, &())?;
-            let info = SymTy::named(lib.name.clone(), ty_name.clone(), ty);
+            let info = SymTy::named(lib.name.clone(), ty_name, ty);
             self.types.insert(id, info);
         }
 
@@ -141,7 +141,7 @@ impl SystemBuilder {
     fn translate_inline<Ref: LibSubref>(&mut self, inline_ty: Ty<Ref>) -> Result<SemId, Error>
     where Ref: Translate<SemId, Context = (), Builder = SystemBuilder, Error = Error> {
         // compute id
-        let id = inline_ty.sem_id_unnamed();
+        let id = inline_ty.id(false);
         // run for nested types
         let ty = inline_ty.translate(self, &())?;
         // add to system


### PR DESCRIPTION
I do think this is a no-go: if we have two types, `Byte(u8)` and `BitFlags(u8)`, these are semantically distinct types, which must have distinct ids.