### PR TITLE
Refactor armoring and strict code style

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         feature:
-          - base64
+          - base85
           - serde
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,10 +103,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
-name = "base64"
-version = "0.21.4"
+name = "base85"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "36915bbaca237c626689b5bd14d02f2ba7a5a359d30a2a08be697392e3718079"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "bitflags"
@@ -305,18 +308,18 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -344,7 +347,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -432,7 +435,7 @@ version = "1.6.3"
 dependencies = [
  "amplify",
  "baid58",
- "base64",
+ "base85",
  "half",
  "indexmap",
  "serde",
@@ -466,13 +469,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "1726efe18f42ae774cc644f330953a5e7b3c3003d3edcecf18850fe9d4dd9afb"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -554,7 +577,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
  "wasm-bindgen-shared",
 ]
 
@@ -576,7 +599,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,15 @@ exclude = [".github"]
 
 [[bin]]
 name = "std-stl"
-required-features = ["base64"]
+required-features = ["base85"]
 
 [[bin]]
 name = "strict-stl"
-required-features = ["base64"]
+required-features = ["base85"]
 
 [[test]]
 name = "reflect"
-required-features = ["base64"]
+required-features = ["base85"]
 
 [dependencies]
 amplify = { version = "4.5.0", features = ["apfloat"] }
@@ -31,7 +31,7 @@ indexmap = "2.0.2"
 baid58 = "0.4.4"
 half = "2.2.0"
 sha2 = "0.10.8"
-base64 = { version = "0.21.4", optional = true }
+base85 = { version = "2.0.0", optional = true }
 serde_crate = { package = "serde", version = "1", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
@@ -39,7 +39,7 @@ toml = { version = "0.8.2", optional = true }
 
 [features]
 default = []
-all = ["serde", "base64"]
+all = ["serde", "base85"]
 serde = [
     "serde_crate",
     "serde_json", "serde_yaml", "toml",

--- a/src/ast/ty.rs
+++ b/src/ast/ty.rs
@@ -536,7 +536,7 @@ where Ref: Display
             write!(f, "{variant}")?;
             if last_tag != variant.tag {
                 last_tag = variant.tag;
-                write!(f, ":{last_tag} ")?;
+                write!(f, "={last_tag} ")?;
             } else {
                 f.write_str(" ")?;
             }
@@ -554,7 +554,7 @@ where Ref: Display
             write!(f, "{variant}")?;
             if last_tag != variant.tag {
                 last_tag = variant.tag;
-                write!(f, ":{last_tag} ")?;
+                write!(f, "={last_tag} ")?;
             } else {
                 f.write_str(" ")?;
             }
@@ -618,13 +618,24 @@ impl EnumVariants {
 impl Display for EnumVariants {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut iter = self.iter();
+        let mut last_tag = 0;
         if let Some(variant) = iter.next() {
-            write!(f, "{variant:#}")?;
+            write!(f, "{variant}")?;
+            if variant.tag != last_tag {
+                last_tag = variant.tag;
+                write!(f, "={last_tag}")?;
+            }
+            last_tag += 1;
         }
         let mut chunk_size = None;
         loop {
             for variant in iter.by_ref().take(chunk_size.unwrap_or(3)) {
-                write!(f, " | {variant:#}")?;
+                write!(f, " | {variant}")?;
+                if variant.tag != last_tag {
+                    last_tag = variant.tag;
+                    write!(f, "={last_tag}")?;
+                }
+                last_tag += 1;
             }
             chunk_size = Some(4);
             if iter.len() == 0 {

--- a/src/ast/ty.rs
+++ b/src/ast/ty.rs
@@ -365,7 +365,7 @@ where Ref: Display
         for field in iter {
             Display::fmt(field, f)?;
             if len >= 3 {
-                f.write_str("\n                       , ")?;
+                f.write_str("\n                      , ")?;
             } else {
                 f.write_str(", ")?;
             }
@@ -548,7 +548,7 @@ where Ref: Display
             } else {
                 Display::fmt(ty, f)?;
             }
-            write!(f, "\n                       | ")?;
+            write!(f, "\n                      | ")?;
         }
         if let Some((variant, ty)) = last {
             write!(f, "{variant}")?;
@@ -630,7 +630,7 @@ impl Display for EnumVariants {
             if iter.len() == 0 {
                 break;
             }
-            write!(f, "\n                      ")?;
+            write!(f, "\n                     ")?;
         }
         writeln!(f)
     }

--- a/src/typelib/serialize.rs
+++ b/src/typelib/serialize.rs
@@ -135,7 +135,7 @@ impl Display for SymbolicLib {
             if f.alternate() {
                 writeln!(f, "-- {:0}", ty.id(Some(name)))?;
             }
-            write!(f, "data {name:0$} :: ", f.width().unwrap_or(16))?;
+            write!(f, "data {name:0$} : ", f.width().unwrap_or(16))?;
             Display::fmt(ty, f)?;
             writeln!(f)?;
         }
@@ -156,7 +156,7 @@ impl Display for TypeLib {
         writeln!(f)?;
         writeln!(f)?;
         for (name, ty) in &self.types {
-            writeln!(f, "data {name:16} :: {ty}")?;
+            writeln!(f, "data {name:16} : {ty}")?;
         }
         Ok(())
     }

--- a/src/typelib/serialize.rs
+++ b/src/typelib/serialize.rs
@@ -57,7 +57,7 @@ impl TypeLib {
             StlFormat::Binary => {
                 self.strict_encode(StrictWriter::with(u24::MAX.into_usize(), file))?;
             }
-            #[cfg(feature = "base64")]
+            #[cfg(feature = "base85")]
             StlFormat::Armored => {
                 writeln!(file, "{self:X}")?;
             }
@@ -162,11 +162,9 @@ impl Display for TypeLib {
     }
 }
 
-#[cfg(feature = "base64")]
+#[cfg(feature = "base85")]
 impl fmt::UpperHex for TypeLib {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use base64::Engine;
-
         writeln!(f, "-----BEGIN STRICT TYPE LIB-----")?;
         writeln!(f, "Id: {:-}", self.id())?;
         writeln!(f, "Name: {}", self.name)?;
@@ -188,8 +186,7 @@ impl fmt::UpperHex for TypeLib {
         writeln!(f)?;
 
         let data = self.to_strict_serialized::<0xFFFFFF>().expect("in-memory");
-        let engine = base64::engine::general_purpose::STANDARD;
-        let data = engine.encode(data);
+        let data = base85::encode(&data);
         let mut data = data.as_str();
         while data.len() >= 64 {
             let (line, rest) = data.split_at(64);

--- a/src/typelib/serialize.rs
+++ b/src/typelib/serialize.rs
@@ -112,6 +112,7 @@ impl SymbolicLib {
 
 impl Display for SymbolicLib {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "@context")?;
         writeln!(f, "typelib {}", self.name())?;
         writeln!(f)?;
         for dep in self.dependencies() {

--- a/src/typesys/symbols.rs
+++ b/src/typesys/symbols.rs
@@ -106,18 +106,16 @@ impl Display for Symbols {
     }
 }
 
-#[cfg(feature = "base64")]
+#[cfg(feature = "base85")]
 impl fmt::UpperHex for Symbols {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         use amplify::confinement::U32;
-        use base64::Engine;
 
         writeln!(f, "-----BEGIN STRICT SYMBOL SYSTEM-----")?;
         writeln!(f)?;
 
         let data = self.to_strict_serialized::<U32>().expect("in-memory");
-        let engine = base64::engine::general_purpose::STANDARD;
-        let data = engine.encode(data);
+        let data = base85::encode(&data);
         let mut data = data.as_str();
         while data.len() >= 64 {
             let (line, rest) = data.split_at(64);
@@ -204,11 +202,10 @@ impl Display for SymbolicSys {
     }
 }
 
-#[cfg(feature = "base64")]
+#[cfg(feature = "base85")]
 impl fmt::UpperHex for SymbolicSys {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         use amplify::confinement::U32;
-        use base64::Engine;
 
         let id = self.id();
 
@@ -217,8 +214,7 @@ impl fmt::UpperHex for SymbolicSys {
         writeln!(f)?;
 
         let data = self.to_strict_serialized::<U32>().expect("in-memory");
-        let engine = base64::engine::general_purpose::STANDARD;
-        let data = engine.encode(data);
+        let data = base85::encode(&data);
         let mut data = data.as_str();
         while data.len() >= 64 {
             let (line, rest) = data.split_at(64);

--- a/src/typesys/symbols.rs
+++ b/src/typesys/symbols.rs
@@ -195,9 +195,9 @@ impl Display for SymbolicSys {
             match self.lookup(*id) {
                 Some(fqn) => {
                     writeln!(f, "-- {id:0}")?;
-                    writeln!(f, "data {fqn} :: {:0}", ty)?;
+                    writeln!(f, "data {fqn} : {:0}", ty)?;
                 }
-                None => writeln!(f, "data {id:0} :: {:0}", ty)?,
+                None => writeln!(f, "data {id:0} : {:0}", ty)?,
             }
         }
         Ok(())

--- a/src/typesys/type_sys.rs
+++ b/src/typesys/type_sys.rs
@@ -144,11 +144,10 @@ impl Display for TypeSystem {
     }
 }
 
-#[cfg(feature = "base64")]
+#[cfg(feature = "base85")]
 impl fmt::UpperHex for TypeSystem {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         use amplify::confinement::U32;
-        use base64::Engine;
 
         let id = self.id();
 
@@ -157,8 +156,7 @@ impl fmt::UpperHex for TypeSystem {
         writeln!(f)?;
 
         let data = self.to_strict_serialized::<U32>().expect("in-memory");
-        let engine = base64::engine::general_purpose::STANDARD;
-        let data = engine.encode(data);
+        let data = base85::encode(&data);
         let mut data = data.as_str();
         while data.len() >= 64 {
             let (line, rest) = data.split_at(64);

--- a/src/typesys/type_sys.rs
+++ b/src/typesys/type_sys.rs
@@ -138,7 +138,7 @@ impl Display for TypeSystem {
         writeln!(f, "typesys -- {}", self.id())?;
         writeln!(f)?;
         for (id, ty) in &self.0 {
-            writeln!(f, "data {id:-} :: {:-}", ty)?;
+            writeln!(f, "data {id:-} : {:-}", ty)?;
         }
         Ok(())
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,7 +40,7 @@ pub enum StlFormat {
     Source,
     #[display("stl")]
     Binary,
-    #[cfg(feature = "base64")]
+    #[cfg(feature = "base85")]
     #[display("sta")]
     Armored,
 }
@@ -51,7 +51,7 @@ impl FromStr for StlFormat {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "stl" => Ok(StlFormat::Binary),
-            #[cfg(feature = "base64")]
+            #[cfg(feature = "base85")]
             "sta" => Ok(StlFormat::Armored),
             "sty" => Ok(StlFormat::Source),
             invalid => Err(UnknownFormat(invalid.to_owned())),

--- a/stl/Std@0.1.0.sty
+++ b/stl/Std@0.1.0.sty
@@ -13,197 +13,197 @@ typelib Std
 -- no dependencies
 
 -- urn:ubideco:semid:55LGxTk42rZVmuXepF2FJNfP52h3QG5pBnBaY1VnnvnP#quiet-opinion-saddle
-data Alpha            : A:65 | B:66 | C:67 | D:68
-                      | E:69 | F:70 | G:71 | H:72
-                      | I:73 | J:74 | K:75 | L:76
-                      | M:77 | N:78 | O:79 | P:80
-                      | Q:81 | R:82 | S:83 | T:84
-                      | U:85 | V:86 | W:87 | X:88
-                      | Y:89 | Z:90 | a:97 | b:98
-                      | c:99 | d:100 | e:101 | f:102
-                      | g:103 | h:104 | i:105 | j:106
-                      | k:107 | l:108 | m:109 | n:110
-                      | o:111 | p:112 | q:113 | r:114
-                      | s:115 | t:116 | u:117 | v:118
-                      | w:119 | x:120 | y:121 | z:122
+data Alpha            : A=65 | B | C | D
+                      | E | F | G | H
+                      | I | J | K | L
+                      | M | N | O | P
+                      | Q | R | S | T
+                      | U | V | W | X
+                      | Y | Z | a=97 | b
+                      | c | d | e | f
+                      | g | h | i | j
+                      | k | l | m | n
+                      | o | p | q | r
+                      | s | t | u | v
+                      | w | x | y | z
 
 -- urn:ubideco:semid:43EA5YjDDUMdgMApG3xuUWGSzDXKr6U5b9gtgLwuqCc3#simon-pegasus-stop
-data AlphaCaps        : A:65 | B:66 | C:67 | D:68
-                      | E:69 | F:70 | G:71 | H:72
-                      | I:73 | J:74 | K:75 | L:76
-                      | M:77 | N:78 | O:79 | P:80
-                      | Q:81 | R:82 | S:83 | T:84
-                      | U:85 | V:86 | W:87 | X:88
-                      | Y:89 | Z:90
+data AlphaCaps        : A=65 | B | C | D
+                      | E | F | G | H
+                      | I | J | K | L
+                      | M | N | O | P
+                      | Q | R | S | T
+                      | U | V | W | X
+                      | Y | Z
 
 -- urn:ubideco:semid:7U5NvJNf343ZzFXsqW2DBYtTSvrb3YdL6oxYd2BaMsVr#magnet-section-latin
-data AlphaCapsNum     : zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57 | A:65 | B:66
-                      | C:67 | D:68 | E:69 | F:70
-                      | G:71 | H:72 | I:73 | J:74
-                      | K:75 | L:76 | M:77 | N:78
-                      | O:79 | P:80 | Q:81 | R:82
-                      | S:83 | T:84 | U:85 | V:86
-                      | W:87 | X:88 | Y:89 | Z:90
+data AlphaCapsNum     : zero=48 | one | two | three
+                      | four | five | six | seven
+                      | eight | nine | A=65 | B
+                      | C | D | E | F
+                      | G | H | I | J
+                      | K | L | M | N
+                      | O | P | Q | R
+                      | S | T | U | V
+                      | W | X | Y | Z
 
 -- urn:ubideco:semid:DZX8CtQMz2kGByNeWpSpWzor5EPoeQ1LRsSWcR13w9bH#disco-ibiza-mile
-data AlphaNum         : zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57 | A:65 | B:66
-                      | C:67 | D:68 | E:69 | F:70
-                      | G:71 | H:72 | I:73 | J:74
-                      | K:75 | L:76 | M:77 | N:78
-                      | O:79 | P:80 | Q:81 | R:82
-                      | S:83 | T:84 | U:85 | V:86
-                      | W:87 | X:88 | Y:89 | Z:90
-                      | a:97 | b:98 | c:99 | d:100
-                      | e:101 | f:102 | g:103 | h:104
-                      | i:105 | j:106 | k:107 | l:108
-                      | m:109 | n:110 | o:111 | p:112
-                      | q:113 | r:114 | s:115 | t:116
-                      | u:117 | v:118 | w:119 | x:120
-                      | y:121 | z:122
+data AlphaNum         : zero=48 | one | two | three
+                      | four | five | six | seven
+                      | eight | nine | A=65 | B
+                      | C | D | E | F
+                      | G | H | I | J
+                      | K | L | M | N
+                      | O | P | Q | R
+                      | S | T | U | V
+                      | W | X | Y | Z
+                      | a=97 | b | c | d
+                      | e | f | g | h
+                      | i | j | k | l
+                      | m | n | o | p
+                      | q | r | s | t
+                      | u | v | w | x
+                      | y | z
 
 -- urn:ubideco:semid:4UQSpEBq39vFqEBYDaLEMaQ6qJYGDiEFsGFYzv7U7ipA#good-trumpet-today
-data AlphaNumDash     : dash:45 | zero:48 | one:49 | two:50
-                      | three:51 | four:52 | five:53 | six:54
-                      | seven:55 | eight:56 | nine:57 | A:65
-                      | B:66 | C:67 | D:68 | E:69
-                      | F:70 | G:71 | H:72 | I:73
-                      | J:74 | K:75 | L:76 | M:77
-                      | N:78 | O:79 | P:80 | Q:81
-                      | R:82 | S:83 | T:84 | U:85
-                      | V:86 | W:87 | X:88 | Y:89
-                      | Z:90 | a:97 | b:98 | c:99
-                      | d:100 | e:101 | f:102 | g:103
-                      | h:104 | i:105 | j:106 | k:107
-                      | l:108 | m:109 | n:110 | o:111
-                      | p:112 | q:113 | r:114 | s:115
-                      | t:116 | u:117 | v:118 | w:119
-                      | x:120 | y:121 | z:122
+data AlphaNumDash     : dash=45 | zero=48 | one | two
+                      | three | four | five | six
+                      | seven | eight | nine | A=65
+                      | B | C | D | E
+                      | F | G | H | I
+                      | J | K | L | M
+                      | N | O | P | Q
+                      | R | S | T | U
+                      | V | W | X | Y
+                      | Z | a=97 | b | c
+                      | d | e | f | g
+                      | h | i | j | k
+                      | l | m | n | o
+                      | p | q | r | s
+                      | t | u | v | w
+                      | x | y | z
 
 -- urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa
-data AlphaNumLodash   : zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57 | A:65 | B:66
-                      | C:67 | D:68 | E:69 | F:70
-                      | G:71 | H:72 | I:73 | J:74
-                      | K:75 | L:76 | M:77 | N:78
-                      | O:79 | P:80 | Q:81 | R:82
-                      | S:83 | T:84 | U:85 | V:86
-                      | W:87 | X:88 | Y:89 | Z:90
-                      | lodash:95 | a:97 | b:98 | c:99
-                      | d:100 | e:101 | f:102 | g:103
-                      | h:104 | i:105 | j:106 | k:107
-                      | l:108 | m:109 | n:110 | o:111
-                      | p:112 | q:113 | r:114 | s:115
-                      | t:116 | u:117 | v:118 | w:119
-                      | x:120 | y:121 | z:122
+data AlphaNumLodash   : zero=48 | one | two | three
+                      | four | five | six | seven
+                      | eight | nine | A=65 | B
+                      | C | D | E | F
+                      | G | H | I | J
+                      | K | L | M | N
+                      | O | P | Q | R
+                      | S | T | U | V
+                      | W | X | Y | Z
+                      | lodash=95 | a=97 | b | c
+                      | d | e | f | g
+                      | h | i | j | k
+                      | l | m | n | o
+                      | p | q | r | s
+                      | t | u | v | w
+                      | x | y | z
 
 -- urn:ubideco:semid:HmLtNhtTNv8cdSDzKcU3p1i3jcJS6TWkrRCw1vYABFJG#song-accent-mammal
-data AlphaSmall       : a:97 | b:98 | c:99 | d:100
-                      | e:101 | f:102 | g:103 | h:104
-                      | i:105 | j:106 | k:107 | l:108
-                      | m:109 | n:110 | o:111 | p:112
-                      | q:113 | r:114 | s:115 | t:116
-                      | u:117 | v:118 | w:119 | x:120
-                      | y:121 | z:122
+data AlphaSmall       : a=97 | b | c | d
+                      | e | f | g | h
+                      | i | j | k | l
+                      | m | n | o | p
+                      | q | r | s | t
+                      | u | v | w | x
+                      | y | z
 
 -- urn:ubideco:semid:2NFrhqQqGNDA4HujyTW2pmcjtrN5sbtFfpPFXPPYcGER#aloha-lunar-felix
-data Ascii            : nul:0 | soh:1 | stx:2 | etx:3
-                      | eot:4 | enq:5 | ack:6 | bel:7
-                      | bs:8 | ht:9 | lf:10 | vt:11
-                      | ff:12 | cr:13 | so:14 | si:15
-                      | dle:16 | dc1:17 | dc2:18 | dc3:19
-                      | dc4:20 | nack:21 | syn:22 | etb:23
-                      | can:24 | em:25 | sub:26 | esc:27
-                      | fs:28 | gs:29 | rs:30 | us:31
-                      | space:32 | excl:33 | quotes:34 | hash:35
-                      | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
-                      | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
-                      | comma:44 | minus:45 | dot:46 | slash:47
-                      | zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57 | colon:58 | semiColon:59
-                      | less:60 | equal:61 | greater:62 | question:63
-                      | at:64 | A:65 | B:66 | C:67
-                      | D:68 | E:69 | F:70 | G:71
-                      | H:72 | I:73 | J:74 | K:75
-                      | L:76 | M:77 | N:78 | O:79
-                      | P:80 | Q:81 | R:82 | S:83
-                      | T:84 | U:85 | V:86 | W:87
-                      | X:88 | Y:89 | Z:90 | sqBracketL:91
-                      | backSlash:92 | sqBracketR:93 | caret:94 | lodash:95
-                      | backtick:96 | a:97 | b:98 | c:99
-                      | d:100 | e:101 | f:102 | g:103
-                      | h:104 | i:105 | j:106 | k:107
-                      | l:108 | m:109 | n:110 | o:111
-                      | p:112 | q:113 | r:114 | s:115
-                      | t:116 | u:117 | v:118 | w:119
-                      | x:120 | y:121 | z:122 | cBracketL:123
-                      | pipe:124 | cBracketR:125 | tilde:126 | del:127
+data Ascii            : nul | soh | stx | etx
+                      | eot | enq | ack | bel
+                      | bs | ht | lf | vt
+                      | ff | cr | so | si
+                      | dle | dc1 | dc2 | dc3
+                      | dc4 | nack | syn | etb
+                      | can | em | sub | esc
+                      | fs | gs | rs | us
+                      | space | excl | quotes | hash
+                      | dollar | percent | ampersand | apostrophe
+                      | bracketL | bracketR | asterisk | plus
+                      | comma | minus | dot | slash
+                      | zero | one | two | three
+                      | four | five | six | seven
+                      | eight | nine | colon | semiColon
+                      | less | equal | greater | question
+                      | at | A | B | C
+                      | D | E | F | G
+                      | H | I | J | K
+                      | L | M | N | O
+                      | P | Q | R | S
+                      | T | U | V | W
+                      | X | Y | Z | sqBracketL
+                      | backSlash | sqBracketR | caret | lodash
+                      | backtick | a | b | c
+                      | d | e | f | g
+                      | h | i | j | k
+                      | l | m | n | o
+                      | p | q | r | s
+                      | t | u | v | w
+                      | x | y | z | cBracketL
+                      | pipe | cBracketR | tilde | del
 
 -- urn:ubideco:semid:mbH4meZSjxky12xHm9pg3rw8VoGxEa6rXtt6dAMZLbt#diet-oxford-window
-data AsciiPrintable   : space:32 | excl:33 | quotes:34 | hash:35
-                      | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
-                      | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
-                      | comma:44 | minus:45 | dot:46 | slash:47
-                      | zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57 | colon:58 | semiColon:59
-                      | less:60 | equal:61 | greater:62 | question:63
-                      | at:64 | A:65 | B:66 | C:67
-                      | D:68 | E:69 | F:70 | G:71
-                      | H:72 | I:73 | J:74 | K:75
-                      | L:76 | M:77 | N:78 | O:79
-                      | P:80 | Q:81 | R:82 | S:83
-                      | T:84 | U:85 | V:86 | W:87
-                      | X:88 | Y:89 | Z:90 | sqBracketL:91
-                      | backSlash:92 | sqBracketR:93 | caret:94 | lodash:95
-                      | backtick:96 | a:97 | b:98 | c:99
-                      | d:100 | e:101 | f:102 | g:103
-                      | h:104 | i:105 | j:106 | k:107
-                      | l:108 | m:109 | n:110 | o:111
-                      | p:112 | q:113 | r:114 | s:115
-                      | t:116 | u:117 | v:118 | w:119
-                      | x:120 | y:121 | z:122 | cBracketL:123
-                      | pipe:124 | cBracketR:125 | tilde:126
+data AsciiPrintable   : space=32 | excl | quotes | hash
+                      | dollar | percent | ampersand | apostrophe
+                      | bracketL | bracketR | asterisk | plus
+                      | comma | minus | dot | slash
+                      | zero | one | two | three
+                      | four | five | six | seven
+                      | eight | nine | colon | semiColon
+                      | less | equal | greater | question
+                      | at | A | B | C
+                      | D | E | F | G
+                      | H | I | J | K
+                      | L | M | N | O
+                      | P | Q | R | S
+                      | T | U | V | W
+                      | X | Y | Z | sqBracketL
+                      | backSlash | sqBracketR | caret | lodash
+                      | backtick | a | b | c
+                      | d | e | f | g
+                      | h | i | j | k
+                      | l | m | n | o
+                      | p | q | r | s
+                      | t | u | v | w
+                      | x | y | z | cBracketL
+                      | pipe | cBracketR | tilde
 
 -- urn:ubideco:semid:7ZhBHGSJm9ixmm8Z9vCX7i5Ga7j5xrW8t11nsb1Cgpnx#laser-madam-maxwell
-data Bool             : false:0 | true:1
+data Bool             : false | true
 
 -- urn:ubideco:semid:DfVXYs8NyS6G5QLTQMUELHWGkSoenXDw3ZFrHzG3LjMW#amanda-spider-diamond
-data Dec              : zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57
+data Dec              : zero=48 | one | two | three
+                      | four | five | six | seven
+                      | eight | nine
 
 -- urn:ubideco:semid:H5T3iaCVzmGH5BcotfpzcRNb5Z1ri27rwVrRhJ6UosU6#invest-moral-anvil
-data HexDecCaps       : zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57 | ten:65 | eleven:66
-                      | twelve:67 | thirteen:68 | fourteen:69 | fifteen:70
+data HexDecCaps       : zero=48 | one | two | three
+                      | four | five | six | seven
+                      | eight | nine | ten=65 | eleven
+                      | twelve | thirteen | fourteen | fifteen
 
 -- urn:ubideco:semid:CBhZBmVRHY5sgou91KEAQrxun6kQQdbCPRekEEoB5Lik#forum-sahara-email
-data HexDecSmall      : zero:48 | one:49 | two:50 | three:51
-                      | four:52 | five:53 | six:54 | seven:55
-                      | eight:56 | nine:57 | ten:97 | eleven:98
-                      | twelve:99 | thirteen:100 | fourteen:101 | fifteen:102
+data HexDecSmall      : zero=48 | one | two | three
+                      | four | five | six | seven
+                      | eight | nine | ten=97 | eleven
+                      | twelve | thirteen | fourteen | fifteen
 
 -- urn:ubideco:semid:BrEhDdRPrktqBgsNbgsmUagRz9b5n5csfbmif8Y7Bcc8#east-invest-harvest
-data U4               : u4_0:0 | u4_1:1 | u4_2:2 | u4_3:3
-                      | u4_4:4 | u4_5:5 | u4_6:6 | u4_7:7
-                      | u4_8:8 | u4_9:9 | u4_10:10 | u4_11:11
-                      | u4_12:12 | u4_13:13 | u4_14:14 | u4_15:15
+data U4               : u4_0 | u4_1 | u4_2 | u4_3
+                      | u4_4 | u4_5 | u4_6 | u4_7
+                      | u4_8 | u4_9 | u4_10 | u4_11
+                      | u4_12 | u4_13 | u4_14 | u4_15
 
 -- urn:ubideco:semid:3MDHMYsJt8d1gUiyx5vGCWcNLQ7biek6UTjHg3ksW4Bf#ground-volume-singer
-data U5               : u5_0:0 | u5_1:1 | u5_2:2 | u5_3:3
-                      | u5_4:4 | u5_5:5 | u5_6:6 | u5_7:7
-                      | u5_8:8 | u5_9:9 | u5_10:10 | u5_11:11
-                      | u5_12:12 | u5_13:13 | u5_14:14 | u5_15:15
-                      | u5_16:16 | u5_17:17 | u5_18:18 | u5_19:19
-                      | u5_20:20 | u5_21:21 | u5_22:22 | u5_23:23
-                      | u5_24:24 | u5_25:25 | u5_26:26 | u5_27:27
-                      | u5_28:28 | u5_29:29 | u5_30:30 | u5_31:31
+data U5               : u5_0 | u5_1 | u5_2 | u5_3
+                      | u5_4 | u5_5 | u5_6 | u5_7
+                      | u5_8 | u5_9 | u5_10 | u5_11
+                      | u5_12 | u5_13 | u5_14 | u5_15
+                      | u5_16 | u5_17 | u5_18 | u5_19
+                      | u5_20 | u5_21 | u5_22 | u5_23
+                      | u5_24 | u5_25 | u5_26 | u5_27
+                      | u5_28 | u5_29 | u5_30 | u5_31
 
 

--- a/stl/Std@0.1.0.sty
+++ b/stl/Std@0.1.0.sty
@@ -13,197 +13,197 @@ typelib Std
 -- no dependencies
 
 -- urn:ubideco:semid:55LGxTk42rZVmuXepF2FJNfP52h3QG5pBnBaY1VnnvnP#quiet-opinion-saddle
-data Alpha            :: A:65 | B:66 | C:67 | D:68
-                       | E:69 | F:70 | G:71 | H:72
-                       | I:73 | J:74 | K:75 | L:76
-                       | M:77 | N:78 | O:79 | P:80
-                       | Q:81 | R:82 | S:83 | T:84
-                       | U:85 | V:86 | W:87 | X:88
-                       | Y:89 | Z:90 | a:97 | b:98
-                       | c:99 | d:100 | e:101 | f:102
-                       | g:103 | h:104 | i:105 | j:106
-                       | k:107 | l:108 | m:109 | n:110
-                       | o:111 | p:112 | q:113 | r:114
-                       | s:115 | t:116 | u:117 | v:118
-                       | w:119 | x:120 | y:121 | z:122
+data Alpha            : A:65 | B:66 | C:67 | D:68
+                      | E:69 | F:70 | G:71 | H:72
+                      | I:73 | J:74 | K:75 | L:76
+                      | M:77 | N:78 | O:79 | P:80
+                      | Q:81 | R:82 | S:83 | T:84
+                      | U:85 | V:86 | W:87 | X:88
+                      | Y:89 | Z:90 | a:97 | b:98
+                      | c:99 | d:100 | e:101 | f:102
+                      | g:103 | h:104 | i:105 | j:106
+                      | k:107 | l:108 | m:109 | n:110
+                      | o:111 | p:112 | q:113 | r:114
+                      | s:115 | t:116 | u:117 | v:118
+                      | w:119 | x:120 | y:121 | z:122
 
 -- urn:ubideco:semid:43EA5YjDDUMdgMApG3xuUWGSzDXKr6U5b9gtgLwuqCc3#simon-pegasus-stop
-data AlphaCaps        :: A:65 | B:66 | C:67 | D:68
-                       | E:69 | F:70 | G:71 | H:72
-                       | I:73 | J:74 | K:75 | L:76
-                       | M:77 | N:78 | O:79 | P:80
-                       | Q:81 | R:82 | S:83 | T:84
-                       | U:85 | V:86 | W:87 | X:88
-                       | Y:89 | Z:90
+data AlphaCaps        : A:65 | B:66 | C:67 | D:68
+                      | E:69 | F:70 | G:71 | H:72
+                      | I:73 | J:74 | K:75 | L:76
+                      | M:77 | N:78 | O:79 | P:80
+                      | Q:81 | R:82 | S:83 | T:84
+                      | U:85 | V:86 | W:87 | X:88
+                      | Y:89 | Z:90
 
 -- urn:ubideco:semid:7U5NvJNf343ZzFXsqW2DBYtTSvrb3YdL6oxYd2BaMsVr#magnet-section-latin
-data AlphaCapsNum     :: zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57 | A:65 | B:66
-                       | C:67 | D:68 | E:69 | F:70
-                       | G:71 | H:72 | I:73 | J:74
-                       | K:75 | L:76 | M:77 | N:78
-                       | O:79 | P:80 | Q:81 | R:82
-                       | S:83 | T:84 | U:85 | V:86
-                       | W:87 | X:88 | Y:89 | Z:90
+data AlphaCapsNum     : zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57 | A:65 | B:66
+                      | C:67 | D:68 | E:69 | F:70
+                      | G:71 | H:72 | I:73 | J:74
+                      | K:75 | L:76 | M:77 | N:78
+                      | O:79 | P:80 | Q:81 | R:82
+                      | S:83 | T:84 | U:85 | V:86
+                      | W:87 | X:88 | Y:89 | Z:90
 
 -- urn:ubideco:semid:DZX8CtQMz2kGByNeWpSpWzor5EPoeQ1LRsSWcR13w9bH#disco-ibiza-mile
-data AlphaNum         :: zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57 | A:65 | B:66
-                       | C:67 | D:68 | E:69 | F:70
-                       | G:71 | H:72 | I:73 | J:74
-                       | K:75 | L:76 | M:77 | N:78
-                       | O:79 | P:80 | Q:81 | R:82
-                       | S:83 | T:84 | U:85 | V:86
-                       | W:87 | X:88 | Y:89 | Z:90
-                       | a:97 | b:98 | c:99 | d:100
-                       | e:101 | f:102 | g:103 | h:104
-                       | i:105 | j:106 | k:107 | l:108
-                       | m:109 | n:110 | o:111 | p:112
-                       | q:113 | r:114 | s:115 | t:116
-                       | u:117 | v:118 | w:119 | x:120
-                       | y:121 | z:122
+data AlphaNum         : zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57 | A:65 | B:66
+                      | C:67 | D:68 | E:69 | F:70
+                      | G:71 | H:72 | I:73 | J:74
+                      | K:75 | L:76 | M:77 | N:78
+                      | O:79 | P:80 | Q:81 | R:82
+                      | S:83 | T:84 | U:85 | V:86
+                      | W:87 | X:88 | Y:89 | Z:90
+                      | a:97 | b:98 | c:99 | d:100
+                      | e:101 | f:102 | g:103 | h:104
+                      | i:105 | j:106 | k:107 | l:108
+                      | m:109 | n:110 | o:111 | p:112
+                      | q:113 | r:114 | s:115 | t:116
+                      | u:117 | v:118 | w:119 | x:120
+                      | y:121 | z:122
 
 -- urn:ubideco:semid:4UQSpEBq39vFqEBYDaLEMaQ6qJYGDiEFsGFYzv7U7ipA#good-trumpet-today
-data AlphaNumDash     :: dash:45 | zero:48 | one:49 | two:50
-                       | three:51 | four:52 | five:53 | six:54
-                       | seven:55 | eight:56 | nine:57 | A:65
-                       | B:66 | C:67 | D:68 | E:69
-                       | F:70 | G:71 | H:72 | I:73
-                       | J:74 | K:75 | L:76 | M:77
-                       | N:78 | O:79 | P:80 | Q:81
-                       | R:82 | S:83 | T:84 | U:85
-                       | V:86 | W:87 | X:88 | Y:89
-                       | Z:90 | a:97 | b:98 | c:99
-                       | d:100 | e:101 | f:102 | g:103
-                       | h:104 | i:105 | j:106 | k:107
-                       | l:108 | m:109 | n:110 | o:111
-                       | p:112 | q:113 | r:114 | s:115
-                       | t:116 | u:117 | v:118 | w:119
-                       | x:120 | y:121 | z:122
+data AlphaNumDash     : dash:45 | zero:48 | one:49 | two:50
+                      | three:51 | four:52 | five:53 | six:54
+                      | seven:55 | eight:56 | nine:57 | A:65
+                      | B:66 | C:67 | D:68 | E:69
+                      | F:70 | G:71 | H:72 | I:73
+                      | J:74 | K:75 | L:76 | M:77
+                      | N:78 | O:79 | P:80 | Q:81
+                      | R:82 | S:83 | T:84 | U:85
+                      | V:86 | W:87 | X:88 | Y:89
+                      | Z:90 | a:97 | b:98 | c:99
+                      | d:100 | e:101 | f:102 | g:103
+                      | h:104 | i:105 | j:106 | k:107
+                      | l:108 | m:109 | n:110 | o:111
+                      | p:112 | q:113 | r:114 | s:115
+                      | t:116 | u:117 | v:118 | w:119
+                      | x:120 | y:121 | z:122
 
 -- urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa
-data AlphaNumLodash   :: zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57 | A:65 | B:66
-                       | C:67 | D:68 | E:69 | F:70
-                       | G:71 | H:72 | I:73 | J:74
-                       | K:75 | L:76 | M:77 | N:78
-                       | O:79 | P:80 | Q:81 | R:82
-                       | S:83 | T:84 | U:85 | V:86
-                       | W:87 | X:88 | Y:89 | Z:90
-                       | lodash:95 | a:97 | b:98 | c:99
-                       | d:100 | e:101 | f:102 | g:103
-                       | h:104 | i:105 | j:106 | k:107
-                       | l:108 | m:109 | n:110 | o:111
-                       | p:112 | q:113 | r:114 | s:115
-                       | t:116 | u:117 | v:118 | w:119
-                       | x:120 | y:121 | z:122
+data AlphaNumLodash   : zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57 | A:65 | B:66
+                      | C:67 | D:68 | E:69 | F:70
+                      | G:71 | H:72 | I:73 | J:74
+                      | K:75 | L:76 | M:77 | N:78
+                      | O:79 | P:80 | Q:81 | R:82
+                      | S:83 | T:84 | U:85 | V:86
+                      | W:87 | X:88 | Y:89 | Z:90
+                      | lodash:95 | a:97 | b:98 | c:99
+                      | d:100 | e:101 | f:102 | g:103
+                      | h:104 | i:105 | j:106 | k:107
+                      | l:108 | m:109 | n:110 | o:111
+                      | p:112 | q:113 | r:114 | s:115
+                      | t:116 | u:117 | v:118 | w:119
+                      | x:120 | y:121 | z:122
 
 -- urn:ubideco:semid:HmLtNhtTNv8cdSDzKcU3p1i3jcJS6TWkrRCw1vYABFJG#song-accent-mammal
-data AlphaSmall       :: a:97 | b:98 | c:99 | d:100
-                       | e:101 | f:102 | g:103 | h:104
-                       | i:105 | j:106 | k:107 | l:108
-                       | m:109 | n:110 | o:111 | p:112
-                       | q:113 | r:114 | s:115 | t:116
-                       | u:117 | v:118 | w:119 | x:120
-                       | y:121 | z:122
+data AlphaSmall       : a:97 | b:98 | c:99 | d:100
+                      | e:101 | f:102 | g:103 | h:104
+                      | i:105 | j:106 | k:107 | l:108
+                      | m:109 | n:110 | o:111 | p:112
+                      | q:113 | r:114 | s:115 | t:116
+                      | u:117 | v:118 | w:119 | x:120
+                      | y:121 | z:122
 
 -- urn:ubideco:semid:2NFrhqQqGNDA4HujyTW2pmcjtrN5sbtFfpPFXPPYcGER#aloha-lunar-felix
-data Ascii            :: nul:0 | soh:1 | stx:2 | etx:3
-                       | eot:4 | enq:5 | ack:6 | bel:7
-                       | bs:8 | ht:9 | lf:10 | vt:11
-                       | ff:12 | cr:13 | so:14 | si:15
-                       | dle:16 | dc1:17 | dc2:18 | dc3:19
-                       | dc4:20 | nack:21 | syn:22 | etb:23
-                       | can:24 | em:25 | sub:26 | esc:27
-                       | fs:28 | gs:29 | rs:30 | us:31
-                       | space:32 | excl:33 | quotes:34 | hash:35
-                       | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
-                       | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
-                       | comma:44 | minus:45 | dot:46 | slash:47
-                       | zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57 | colon:58 | semiColon:59
-                       | less:60 | equal:61 | greater:62 | question:63
-                       | at:64 | A:65 | B:66 | C:67
-                       | D:68 | E:69 | F:70 | G:71
-                       | H:72 | I:73 | J:74 | K:75
-                       | L:76 | M:77 | N:78 | O:79
-                       | P:80 | Q:81 | R:82 | S:83
-                       | T:84 | U:85 | V:86 | W:87
-                       | X:88 | Y:89 | Z:90 | sqBracketL:91
-                       | backSlash:92 | sqBracketR:93 | caret:94 | lodash:95
-                       | backtick:96 | a:97 | b:98 | c:99
-                       | d:100 | e:101 | f:102 | g:103
-                       | h:104 | i:105 | j:106 | k:107
-                       | l:108 | m:109 | n:110 | o:111
-                       | p:112 | q:113 | r:114 | s:115
-                       | t:116 | u:117 | v:118 | w:119
-                       | x:120 | y:121 | z:122 | cBracketL:123
-                       | pipe:124 | cBracketR:125 | tilde:126 | del:127
+data Ascii            : nul:0 | soh:1 | stx:2 | etx:3
+                      | eot:4 | enq:5 | ack:6 | bel:7
+                      | bs:8 | ht:9 | lf:10 | vt:11
+                      | ff:12 | cr:13 | so:14 | si:15
+                      | dle:16 | dc1:17 | dc2:18 | dc3:19
+                      | dc4:20 | nack:21 | syn:22 | etb:23
+                      | can:24 | em:25 | sub:26 | esc:27
+                      | fs:28 | gs:29 | rs:30 | us:31
+                      | space:32 | excl:33 | quotes:34 | hash:35
+                      | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
+                      | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
+                      | comma:44 | minus:45 | dot:46 | slash:47
+                      | zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57 | colon:58 | semiColon:59
+                      | less:60 | equal:61 | greater:62 | question:63
+                      | at:64 | A:65 | B:66 | C:67
+                      | D:68 | E:69 | F:70 | G:71
+                      | H:72 | I:73 | J:74 | K:75
+                      | L:76 | M:77 | N:78 | O:79
+                      | P:80 | Q:81 | R:82 | S:83
+                      | T:84 | U:85 | V:86 | W:87
+                      | X:88 | Y:89 | Z:90 | sqBracketL:91
+                      | backSlash:92 | sqBracketR:93 | caret:94 | lodash:95
+                      | backtick:96 | a:97 | b:98 | c:99
+                      | d:100 | e:101 | f:102 | g:103
+                      | h:104 | i:105 | j:106 | k:107
+                      | l:108 | m:109 | n:110 | o:111
+                      | p:112 | q:113 | r:114 | s:115
+                      | t:116 | u:117 | v:118 | w:119
+                      | x:120 | y:121 | z:122 | cBracketL:123
+                      | pipe:124 | cBracketR:125 | tilde:126 | del:127
 
 -- urn:ubideco:semid:mbH4meZSjxky12xHm9pg3rw8VoGxEa6rXtt6dAMZLbt#diet-oxford-window
-data AsciiPrintable   :: space:32 | excl:33 | quotes:34 | hash:35
-                       | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
-                       | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
-                       | comma:44 | minus:45 | dot:46 | slash:47
-                       | zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57 | colon:58 | semiColon:59
-                       | less:60 | equal:61 | greater:62 | question:63
-                       | at:64 | A:65 | B:66 | C:67
-                       | D:68 | E:69 | F:70 | G:71
-                       | H:72 | I:73 | J:74 | K:75
-                       | L:76 | M:77 | N:78 | O:79
-                       | P:80 | Q:81 | R:82 | S:83
-                       | T:84 | U:85 | V:86 | W:87
-                       | X:88 | Y:89 | Z:90 | sqBracketL:91
-                       | backSlash:92 | sqBracketR:93 | caret:94 | lodash:95
-                       | backtick:96 | a:97 | b:98 | c:99
-                       | d:100 | e:101 | f:102 | g:103
-                       | h:104 | i:105 | j:106 | k:107
-                       | l:108 | m:109 | n:110 | o:111
-                       | p:112 | q:113 | r:114 | s:115
-                       | t:116 | u:117 | v:118 | w:119
-                       | x:120 | y:121 | z:122 | cBracketL:123
-                       | pipe:124 | cBracketR:125 | tilde:126
+data AsciiPrintable   : space:32 | excl:33 | quotes:34 | hash:35
+                      | dollar:36 | percent:37 | ampersand:38 | apostrophe:39
+                      | bracketL:40 | bracketR:41 | asterisk:42 | plus:43
+                      | comma:44 | minus:45 | dot:46 | slash:47
+                      | zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57 | colon:58 | semiColon:59
+                      | less:60 | equal:61 | greater:62 | question:63
+                      | at:64 | A:65 | B:66 | C:67
+                      | D:68 | E:69 | F:70 | G:71
+                      | H:72 | I:73 | J:74 | K:75
+                      | L:76 | M:77 | N:78 | O:79
+                      | P:80 | Q:81 | R:82 | S:83
+                      | T:84 | U:85 | V:86 | W:87
+                      | X:88 | Y:89 | Z:90 | sqBracketL:91
+                      | backSlash:92 | sqBracketR:93 | caret:94 | lodash:95
+                      | backtick:96 | a:97 | b:98 | c:99
+                      | d:100 | e:101 | f:102 | g:103
+                      | h:104 | i:105 | j:106 | k:107
+                      | l:108 | m:109 | n:110 | o:111
+                      | p:112 | q:113 | r:114 | s:115
+                      | t:116 | u:117 | v:118 | w:119
+                      | x:120 | y:121 | z:122 | cBracketL:123
+                      | pipe:124 | cBracketR:125 | tilde:126
 
 -- urn:ubideco:semid:7ZhBHGSJm9ixmm8Z9vCX7i5Ga7j5xrW8t11nsb1Cgpnx#laser-madam-maxwell
-data Bool             :: false:0 | true:1
+data Bool             : false:0 | true:1
 
 -- urn:ubideco:semid:DfVXYs8NyS6G5QLTQMUELHWGkSoenXDw3ZFrHzG3LjMW#amanda-spider-diamond
-data Dec              :: zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57
+data Dec              : zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57
 
 -- urn:ubideco:semid:H5T3iaCVzmGH5BcotfpzcRNb5Z1ri27rwVrRhJ6UosU6#invest-moral-anvil
-data HexDecCaps       :: zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57 | ten:65 | eleven:66
-                       | twelve:67 | thirteen:68 | fourteen:69 | fifteen:70
+data HexDecCaps       : zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57 | ten:65 | eleven:66
+                      | twelve:67 | thirteen:68 | fourteen:69 | fifteen:70
 
 -- urn:ubideco:semid:CBhZBmVRHY5sgou91KEAQrxun6kQQdbCPRekEEoB5Lik#forum-sahara-email
-data HexDecSmall      :: zero:48 | one:49 | two:50 | three:51
-                       | four:52 | five:53 | six:54 | seven:55
-                       | eight:56 | nine:57 | ten:97 | eleven:98
-                       | twelve:99 | thirteen:100 | fourteen:101 | fifteen:102
+data HexDecSmall      : zero:48 | one:49 | two:50 | three:51
+                      | four:52 | five:53 | six:54 | seven:55
+                      | eight:56 | nine:57 | ten:97 | eleven:98
+                      | twelve:99 | thirteen:100 | fourteen:101 | fifteen:102
 
 -- urn:ubideco:semid:BrEhDdRPrktqBgsNbgsmUagRz9b5n5csfbmif8Y7Bcc8#east-invest-harvest
-data U4               :: u4_0:0 | u4_1:1 | u4_2:2 | u4_3:3
-                       | u4_4:4 | u4_5:5 | u4_6:6 | u4_7:7
-                       | u4_8:8 | u4_9:9 | u4_10:10 | u4_11:11
-                       | u4_12:12 | u4_13:13 | u4_14:14 | u4_15:15
+data U4               : u4_0:0 | u4_1:1 | u4_2:2 | u4_3:3
+                      | u4_4:4 | u4_5:5 | u4_6:6 | u4_7:7
+                      | u4_8:8 | u4_9:9 | u4_10:10 | u4_11:11
+                      | u4_12:12 | u4_13:13 | u4_14:14 | u4_15:15
 
 -- urn:ubideco:semid:3MDHMYsJt8d1gUiyx5vGCWcNLQ7biek6UTjHg3ksW4Bf#ground-volume-singer
-data U5               :: u5_0:0 | u5_1:1 | u5_2:2 | u5_3:3
-                       | u5_4:4 | u5_5:5 | u5_6:6 | u5_7:7
-                       | u5_8:8 | u5_9:9 | u5_10:10 | u5_11:11
-                       | u5_12:12 | u5_13:13 | u5_14:14 | u5_15:15
-                       | u5_16:16 | u5_17:17 | u5_18:18 | u5_19:19
-                       | u5_20:20 | u5_21:21 | u5_22:22 | u5_23:23
-                       | u5_24:24 | u5_25:25 | u5_26:26 | u5_27:27
-                       | u5_28:28 | u5_29:29 | u5_30:30 | u5_31:31
+data U5               : u5_0:0 | u5_1:1 | u5_2:2 | u5_3:3
+                      | u5_4:4 | u5_5:5 | u5_6:6 | u5_7:7
+                      | u5_8:8 | u5_9:9 | u5_10:10 | u5_11:11
+                      | u5_12:12 | u5_13:13 | u5_14:14 | u5_15:15
+                      | u5_16:16 | u5_17:17 | u5_18:18 | u5_19:19
+                      | u5_20:20 | u5_21:21 | u5_22:22 | u5_23:23
+                      | u5_24:24 | u5_25:25 | u5_26:26 | u5_27:27
+                      | u5_28:28 | u5_29:29 | u5_30:30 | u5_31:31
 
 

--- a/stl/StrictTypes@0.1.0.sty
+++ b/stl/StrictTypes@0.1.0.sty
@@ -17,169 +17,169 @@ import urn:ubideco:stl:9KALDYR8Nyjq4FdMW6kYoL7vdkWnqPqNuFnmE9qHpNjZ#justice-rock
 
 
 -- urn:ubideco:semid:FV6aCKqTnAc6kavvC48U6WEjAqc4H6UTi2iRTxFrhqPY#silence-tommy-direct
-data Dependency       :: id TypeLibId, name LibName
+data Dependency       : id TypeLibId, name LibName
 -- urn:ubideco:semid:51iuuNfXdzE8dx9Y9QEaiGP2cc7yJzirY4abawBKNGE6#karate-sister-aztec
-data EnumVariants     :: {Variant ^ 1..0xff}
+data EnumVariants     : {Variant ^ 1..0xff}
 -- urn:ubideco:semid:29hz6aMnfcGz3SEVoUv6k5PfZjSPJX7bJpiQj3EKkGwx#ritual-soprano-scholar
-data ExternRef        :: libId TypeLibId, semId SemId
+data ExternRef        : libId TypeLibId, semId SemId
 -- urn:ubideco:semid:2GJ4sjfUm59XEr5Hrcn9hdA9zD9VhHuyjtErnrpH6vEs#phoenix-poker-amanda
-data FieldInlineRef   :: name FieldName, ty InlineRef
+data FieldInlineRef   : name FieldName, ty InlineRef
 -- urn:ubideco:semid:4cYyU4JWGoY76byD4PYLwNsHTrbRiic5PbUDpSQMFYih#pedro-cement-crown
-data FieldInlineRef1  :: name FieldName, ty InlineRef1
+data FieldInlineRef1  : name FieldName, ty InlineRef1
 -- urn:ubideco:semid:5tdhprRvkZVPGAqkYuZT1RmsccSgfg5mz1ohgXH32PLy#serpent-natasha-freddie
-data FieldInlineRef2  :: name FieldName, ty InlineRef2
+data FieldInlineRef2  : name FieldName, ty InlineRef2
 -- urn:ubideco:semid:4NgjiSuLr3txVBAtRWe9t68GiwigifkCB5hzTqo7fQSj#stone-horizon-protect
-data FieldLibRef      :: name FieldName, ty LibRef
+data FieldLibRef      : name FieldName, ty LibRef
 -- urn:ubideco:semid:EXf9yMeW9dZv4Aq4kPcWAgG1pmBDaLKzV6fMqMxckeWK#today-green-neptune
-data FieldName        :: Ident
+data FieldName        : Ident
 -- urn:ubideco:semid:8yQQNsKP7MtL4dVP7dJNXnGutLdhs5xdmx369dp18pea#storm-vega-pegasus
-data FieldSemId       :: name FieldName, ty SemId
+data FieldSemId       : name FieldName, ty SemId
 -- urn:ubideco:semid:9SkVki7nQ7WRGN2ayWjySv7QSh6ftrakdNRbE2sSbUYw#connect-fragile-exile
-data Ident            :: [Std.AlphaNumLodash {- urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa -} ^ 1..0x64]
+data Ident            : [Std.AlphaNumLodash {- urn:ubideco:semid:8iBe2dh8beD1KUairdqCacEcxAr4h55XfUQN2PspWXjz#north-sound-salsa -} ^ 1..0x64]
 -- urn:ubideco:semid:ACXJeMFxSCfKaDXpGZzzDJ9PZrnWERenBSkaVgmqztT9#magnet-llama-drum
-data InlineRef        :: inline TyInlineRef1
-                       | named SemId
-                       | extern ExternRef
+data InlineRef        : inline TyInlineRef1
+                      | named SemId
+                      | extern ExternRef
 -- urn:ubideco:semid:GuvQNNvNkmUT8fJYCXuucUCFSRqoHoy4g2wB54PgnP5D#ramirez-break-ribbon
-data InlineRef1       :: inline TyInlineRef2
-                       | named SemId
-                       | extern ExternRef
+data InlineRef1       : inline TyInlineRef2
+                      | named SemId
+                      | extern ExternRef
 -- urn:ubideco:semid:9VXzdXS3wF1eomrLkmhKMK9kTdVQnWQUW5Fhqbm3E4Ux#gong-tunnel-lexicon
-data InlineRef2       :: named SemId
-                       | extern ExternRef
+data InlineRef2       : named SemId
+                      | extern ExternRef
 -- urn:ubideco:semid:CfGN6VgrTXVEvMF4TVu9vihmn9YEwHFck9GM26Gwfn7k#public-pagoda-bonjour
-data LibName          :: Ident
+data LibName          : Ident
 -- urn:ubideco:semid:HKxXPz1j5bUNYzAyyHE5qghcffX5nUEfJWDP2hSdWyGC#focus-vitamin-plate
-data LibRef           :: inline TyInlineRef
-                       | named SemId
-                       | extern ExternRef
+data LibRef           : inline TyInlineRef
+                      | named SemId
+                      | extern ExternRef
 -- urn:ubideco:semid:94DUadJMLRjBzGtu4sbzw4m1515nWSZSoRBRX6zx94RT#arthur-shelter-bermuda
-data NamedFieldsInlineRef :: [FieldInlineRef ^ 1..0xff]
+data NamedFieldsInlineRef : [FieldInlineRef ^ 1..0xff]
 -- urn:ubideco:semid:FTnqX46y9MLGSmSBaVTYWr5KNB43SiJDgM98eeyE1uEf#zebra-stone-river
-data NamedFieldsInlineRef1 :: [FieldInlineRef1 ^ 1..0xff]
+data NamedFieldsInlineRef1 : [FieldInlineRef1 ^ 1..0xff]
 -- urn:ubideco:semid:A56U8yCFhAKvocfRD2mbE9YemfE5iDQVwygBXeWgA1Hx#java-paper-maze
-data NamedFieldsInlineRef2 :: [FieldInlineRef2 ^ 1..0xff]
+data NamedFieldsInlineRef2 : [FieldInlineRef2 ^ 1..0xff]
 -- urn:ubideco:semid:EDuAn1A4guy6TkgtgKcLksuHPz1AWNxYQRyw1bkXrpGv#silicon-average-gong
-data NamedFieldsLibRef :: [FieldLibRef ^ 1..0xff]
+data NamedFieldsLibRef : [FieldLibRef ^ 1..0xff]
 -- urn:ubideco:semid:7MoLEA46Roi1ELw5DcLEqNhxVJYJ4z2hN1yQHX4RVMFa#local-english-sonata
-data NamedFieldsSemId :: [FieldSemId ^ 1..0xff]
+data NamedFieldsSemId : [FieldSemId ^ 1..0xff]
 -- urn:ubideco:semid:3T3zMmQxuir7TsdjhBLaETJfLH4mr5amAseXDePnzhMT#hobby-cable-puzzle
-data Primitive        :: U8
+data Primitive        : U8
 -- urn:ubideco:semid:8Ckj2p3GLKina636pSKJkj7GB6ft8XeoP4jfGkRUNwtp#cargo-plasma-catalog
-data SemId            :: [Byte ^ 32]
+data SemId            : [Byte ^ 32]
 -- urn:ubideco:semid:9jnMbAs5A91zjK9KDrLuFH42WtinmB8GY6JE6BMY31hw#canoe-gordon-amazon
-data Sizing           :: min U64, max U64
+data Sizing           : min U64, max U64
 -- urn:ubideco:semid:HTSFwsgZjYXJRLbgpT4NXrqn81U1epqjZAJf7Lf4XLT1#pocket-oxford-monster
-data SymbolRef        :: libName LibName
-                       , tyName TypeName
-                       , libId TypeLibId
-                       , semId SemId
+data SymbolRef        : libName LibName
+                      , tyName TypeName
+                      , libId TypeLibId
+                      , semId SemId
 -- urn:ubideco:semid:CatmbYRFh9sq96VaCNZDoxwPSs3QA6U9z8g5mXy5JyeD#diagram-crimson-blast
-data SymbolicSys      :: symbols Symbols, types TypeSystem
+data SymbolicSys      : symbols Symbols, types TypeSystem
 -- urn:ubideco:semid:3YfnJ7fXxmtKqtNg6bUGo9ac8vdwUpqib8R6nGPiJJLF#shock-castle-robin
-data Symbols          :: libs {Dependency}, symbols {TypeSymbol ^ ..0xffffff}
+data Symbols          : libs {Dependency}, symbols {TypeSymbol ^ ..0xffffff}
 -- urn:ubideco:semid:8DRwuKzTL4Le1SS1ZqsRAKXSf5vEeH4GZpBP7C47KQLZ#absent-logo-genius
-data TyInlineRef      :: primitive Primitive
-                       | unicode ()
-                       | enum:3 EnumVariants
-                       | union UnionVariantsInlineRef
-                       | tuple UnnamedFieldsInlineRef
-                       | struct NamedFieldsInlineRef
-                       | array (InlineRef, U16)
-                       | list (InlineRef, Sizing)
-                       | set (InlineRef, Sizing)
-                       | map (InlineRef, InlineRef, Sizing)
+data TyInlineRef      : primitive Primitive
+                      | unicode ()
+                      | enum:3 EnumVariants
+                      | union UnionVariantsInlineRef
+                      | tuple UnnamedFieldsInlineRef
+                      | struct NamedFieldsInlineRef
+                      | array (InlineRef, U16)
+                      | list (InlineRef, Sizing)
+                      | set (InlineRef, Sizing)
+                      | map (InlineRef, InlineRef, Sizing)
 -- urn:ubideco:semid:8uSo7Y1LqX6RZXB9n4B3ckMpVSUXSgBcVe4NDQFcFkFN#taxi-rhino-secret
-data TyInlineRef1     :: primitive Primitive
-                       | unicode ()
-                       | enum:3 EnumVariants
-                       | union UnionVariantsInlineRef1
-                       | tuple UnnamedFieldsInlineRef1
-                       | struct NamedFieldsInlineRef1
-                       | array (InlineRef1, U16)
-                       | list (InlineRef1, Sizing)
-                       | set (InlineRef1, Sizing)
-                       | map (InlineRef1, InlineRef1, Sizing)
+data TyInlineRef1     : primitive Primitive
+                      | unicode ()
+                      | enum:3 EnumVariants
+                      | union UnionVariantsInlineRef1
+                      | tuple UnnamedFieldsInlineRef1
+                      | struct NamedFieldsInlineRef1
+                      | array (InlineRef1, U16)
+                      | list (InlineRef1, Sizing)
+                      | set (InlineRef1, Sizing)
+                      | map (InlineRef1, InlineRef1, Sizing)
 -- urn:ubideco:semid:8Zao2AsxACSZEghypLLtvZe2UELita7DpVS7sQTqcvod#pacific-dolby-result
-data TyInlineRef2     :: primitive Primitive
-                       | unicode ()
-                       | enum:3 EnumVariants
-                       | union UnionVariantsInlineRef2
-                       | tuple UnnamedFieldsInlineRef2
-                       | struct NamedFieldsInlineRef2
-                       | array (InlineRef2, U16)
-                       | list (InlineRef2, Sizing)
-                       | set (InlineRef2, Sizing)
-                       | map (InlineRef2, InlineRef2, Sizing)
+data TyInlineRef2     : primitive Primitive
+                      | unicode ()
+                      | enum:3 EnumVariants
+                      | union UnionVariantsInlineRef2
+                      | tuple UnnamedFieldsInlineRef2
+                      | struct NamedFieldsInlineRef2
+                      | array (InlineRef2, U16)
+                      | list (InlineRef2, Sizing)
+                      | set (InlineRef2, Sizing)
+                      | map (InlineRef2, InlineRef2, Sizing)
 -- urn:ubideco:semid:8Ph3m9aiAfvjV6kHYXBAaK9PeyfGyBgU387PspxCDupQ#russian-sweden-period
-data TyLibRef         :: primitive Primitive
-                       | unicode ()
-                       | enum:3 EnumVariants
-                       | union UnionVariantsLibRef
-                       | tuple UnnamedFieldsLibRef
-                       | struct NamedFieldsLibRef
-                       | array (LibRef, U16)
-                       | list (LibRef, Sizing)
-                       | set (LibRef, Sizing)
-                       | map (LibRef, LibRef, Sizing)
+data TyLibRef         : primitive Primitive
+                      | unicode ()
+                      | enum:3 EnumVariants
+                      | union UnionVariantsLibRef
+                      | tuple UnnamedFieldsLibRef
+                      | struct NamedFieldsLibRef
+                      | array (LibRef, U16)
+                      | list (LibRef, Sizing)
+                      | set (LibRef, Sizing)
+                      | map (LibRef, LibRef, Sizing)
 -- urn:ubideco:semid:5umsZQXgcipmGCn8h2TTged2CDuaSDoDJQzW3BkTr4aK#solo-canal-flower
-data TySemId          :: primitive Primitive
-                       | unicode ()
-                       | enum:3 EnumVariants
-                       | union UnionVariantsSemId
-                       | tuple UnnamedFieldsSemId
-                       | struct NamedFieldsSemId
-                       | array (SemId, U16)
-                       | list (SemId, Sizing)
-                       | set (SemId, Sizing)
-                       | map (SemId, SemId, Sizing)
+data TySemId          : primitive Primitive
+                      | unicode ()
+                      | enum:3 EnumVariants
+                      | union UnionVariantsSemId
+                      | tuple UnnamedFieldsSemId
+                      | struct NamedFieldsSemId
+                      | array (SemId, U16)
+                      | list (SemId, Sizing)
+                      | set (SemId, Sizing)
+                      | map (SemId, SemId, Sizing)
 -- urn:ubideco:semid:AbBubPzzwg8DYXHoASLchKS9KLUQmnX15TPHzuSTenxF#salary-apollo-chicago
-data TypeFqn          :: lib LibName, name TypeName
+data TypeFqn          : lib LibName, name TypeName
 -- urn:ubideco:semid:2qdbDrCxa4pUbo5gUmu4P8b4ja8v3UVJqv4thcekvaZr#gallery-coral-actor
-data TypeLib          :: name LibName
-                       , dependencies {Dependency ^ ..0xff}
-                       , externTypes {LibName -> ^ ..0xff {SemId -> TypeName}}
-                       , types {TypeName -> ^ 1.. TyLibRef}
+data TypeLib          : name LibName
+                      , dependencies {Dependency ^ ..0xff}
+                      , externTypes {LibName -> ^ ..0xff {SemId -> TypeName}}
+                      , types {TypeName -> ^ 1.. TyLibRef}
 -- urn:ubideco:semid:DENrVJmXwRSwiZez8ZgUBsvQkTBTKy86zADExJ68bcaq#jessica-snake-ceramic
-data TypeLibId        :: [Byte ^ 32]
+data TypeLibId        : [Byte ^ 32]
 -- urn:ubideco:semid:BeAZU9i8ViQp3kbm2kXTVTchqzybypmhcFNG7yr1mi39#vega-shock-state
-data TypeName         :: Ident
+data TypeName         : Ident
 -- urn:ubideco:semid:2mWV4gJf12MJKJ93AsXmXqocLkwndHW79NS1G2xoZrpy#match-alaska-fragile
-data TypeSymbol       :: id SemId, fqn TypeFqn?
+data TypeSymbol       : id SemId, fqn TypeFqn?
 -- urn:ubideco:semid:46cvynAxpvUUTPvrCDQARcmwHHETLhkcgy8345mN1LLq#clara-tonight-office
-data TypeSysId        :: [Byte ^ 32]
+data TypeSysId        : [Byte ^ 32]
 -- urn:ubideco:semid:A3dqfyLgVP7VBHEeYPKkBvAtouxNvKS2EFNYeKXsN2iy#system-marco-torpedo
-data TypeSystem       :: {SemId -> ^ ..0xffffff TySemId}
+data TypeSystem       : {SemId -> ^ ..0xffffff TySemId}
 -- urn:ubideco:semid:6AWJKZiwinJPiiidywfDKCLnkYMzy1mQNU46q9AqLrRj#sonar-voodoo-change
-data UnionVariantsInlineRef :: {U8 -> ^ ..0xff VariantInfoInlineRef}
+data UnionVariantsInlineRef : {U8 -> ^ ..0xff VariantInfoInlineRef}
 -- urn:ubideco:semid:B38wGtyv8gja4Z1RgX4BYSkwLg2SWNfWoHy6Lm74ZFGA#japan-hope-monster
-data UnionVariantsInlineRef1 :: {U8 -> ^ ..0xff VariantInfoInlineRef1}
+data UnionVariantsInlineRef1 : {U8 -> ^ ..0xff VariantInfoInlineRef1}
 -- urn:ubideco:semid:7wf6GJPBgC6NKeB1JfK9W72ZDNkPFfd6C2R19FiL5Yn8#stage-secret-bonus
-data UnionVariantsInlineRef2 :: {U8 -> ^ ..0xff VariantInfoInlineRef2}
+data UnionVariantsInlineRef2 : {U8 -> ^ ..0xff VariantInfoInlineRef2}
 -- urn:ubideco:semid:zPC3EHHjZnDwJGNih8rYV52sjgfpNrpZz2eZey47d28#violet-mailbox-kimono
-data UnionVariantsLibRef :: {U8 -> ^ ..0xff VariantInfoLibRef}
+data UnionVariantsLibRef : {U8 -> ^ ..0xff VariantInfoLibRef}
 -- urn:ubideco:semid:DkkFcBhrhogm6ACVw48aLr9FJ2mMy5Pi6nySsobbrBb5#sponsor-lotus-pretend
-data UnionVariantsSemId :: {U8 -> ^ ..0xff VariantInfoSemId}
+data UnionVariantsSemId : {U8 -> ^ ..0xff VariantInfoSemId}
 -- urn:ubideco:semid:79HiyC2Lm1dFG4ZcaeyfLT94RjnteSmkRkcReVdMzTM4#silk-mega-loyal
-data UnnamedFieldsInlineRef :: [InlineRef ^ 1..0xff]
+data UnnamedFieldsInlineRef : [InlineRef ^ 1..0xff]
 -- urn:ubideco:semid:udGXz59QaShngQ467mwGx42uto92AQbvR2gQyZM3ihb#rabbit-burma-geneva
-data UnnamedFieldsInlineRef1 :: [InlineRef1 ^ 1..0xff]
+data UnnamedFieldsInlineRef1 : [InlineRef1 ^ 1..0xff]
 -- urn:ubideco:semid:4P9ySyD5yTC9pVRkiRENje4ub4E2avLiQuB1hbUNWgYx#fashion-april-special
-data UnnamedFieldsInlineRef2 :: [InlineRef2 ^ 1..0xff]
+data UnnamedFieldsInlineRef2 : [InlineRef2 ^ 1..0xff]
 -- urn:ubideco:semid:4CvGjQBATcDfDMPF2QNu8vej45ehRatkwRm7LK5MZ7MK#poetic-century-ozone
-data UnnamedFieldsLibRef :: [LibRef ^ 1..0xff]
+data UnnamedFieldsLibRef : [LibRef ^ 1..0xff]
 -- urn:ubideco:semid:AHCYFYAtpW2kxJpVpmD6suNB9epMm6zffaDMtotKcXvh#signal-satire-russian
-data UnnamedFieldsSemId :: [SemId ^ 1..0xff]
+data UnnamedFieldsSemId : [SemId ^ 1..0xff]
 -- urn:ubideco:semid:BPoLofDtYzh8rRxa2ss4SxWc9VsuF6wtfVNqbdstcrXf#sabrina-stage-harmony
-data Variant          :: name FieldName, tag U8
+data Variant          : name FieldName, tag U8
 -- urn:ubideco:semid:Cy1X8nRdwM4yHmaSZ3ahiuBdsAe3RbNp6oR56LCzagx9#speech-fractal-cable
-data VariantInfoInlineRef :: name FieldName, ty InlineRef
+data VariantInfoInlineRef : name FieldName, ty InlineRef
 -- urn:ubideco:semid:FQoVf49AYi7SWk5zAKMA6tttgCDPBzRTcdmBogEdUkz9#avalon-ozone-clinic
-data VariantInfoInlineRef1 :: name FieldName, ty InlineRef1
+data VariantInfoInlineRef1 : name FieldName, ty InlineRef1
 -- urn:ubideco:semid:8y3bWbWqemKa5z8AQ6yUFizMuZ9FQbtZjXw5LeKsipvq#equal-flood-crater
-data VariantInfoInlineRef2 :: name FieldName, ty InlineRef2
+data VariantInfoInlineRef2 : name FieldName, ty InlineRef2
 -- urn:ubideco:semid:ByNU4fSLr6cr9YYjyNf6ja3ErMnKeQYPtWmyZy1YHCq8#process-empire-observe
-data VariantInfoLibRef :: name FieldName, ty LibRef
+data VariantInfoLibRef : name FieldName, ty LibRef
 -- urn:ubideco:semid:8QSJ14SZzimY7RGYUaH9w71kAgxLjECPAs9x84sk28uu#labor-south-newton
-data VariantInfoSemId :: name FieldName, ty SemId
+data VariantInfoSemId : name FieldName, ty SemId
 

--- a/stl/StrictTypes@0.1.0.sty
+++ b/stl/StrictTypes@0.1.0.sty
@@ -81,7 +81,7 @@ data Symbols          : libs {Dependency}, symbols {TypeSymbol ^ ..0xffffff}
 -- urn:ubideco:semid:8DRwuKzTL4Le1SS1ZqsRAKXSf5vEeH4GZpBP7C47KQLZ#absent-logo-genius
 data TyInlineRef      : primitive Primitive
                       | unicode ()
-                      | enum:3 EnumVariants
+                      | enum=3 EnumVariants
                       | union UnionVariantsInlineRef
                       | tuple UnnamedFieldsInlineRef
                       | struct NamedFieldsInlineRef
@@ -92,7 +92,7 @@ data TyInlineRef      : primitive Primitive
 -- urn:ubideco:semid:8uSo7Y1LqX6RZXB9n4B3ckMpVSUXSgBcVe4NDQFcFkFN#taxi-rhino-secret
 data TyInlineRef1     : primitive Primitive
                       | unicode ()
-                      | enum:3 EnumVariants
+                      | enum=3 EnumVariants
                       | union UnionVariantsInlineRef1
                       | tuple UnnamedFieldsInlineRef1
                       | struct NamedFieldsInlineRef1
@@ -103,7 +103,7 @@ data TyInlineRef1     : primitive Primitive
 -- urn:ubideco:semid:8Zao2AsxACSZEghypLLtvZe2UELita7DpVS7sQTqcvod#pacific-dolby-result
 data TyInlineRef2     : primitive Primitive
                       | unicode ()
-                      | enum:3 EnumVariants
+                      | enum=3 EnumVariants
                       | union UnionVariantsInlineRef2
                       | tuple UnnamedFieldsInlineRef2
                       | struct NamedFieldsInlineRef2
@@ -114,7 +114,7 @@ data TyInlineRef2     : primitive Primitive
 -- urn:ubideco:semid:8Ph3m9aiAfvjV6kHYXBAaK9PeyfGyBgU387PspxCDupQ#russian-sweden-period
 data TyLibRef         : primitive Primitive
                       | unicode ()
-                      | enum:3 EnumVariants
+                      | enum=3 EnumVariants
                       | union UnionVariantsLibRef
                       | tuple UnnamedFieldsLibRef
                       | struct NamedFieldsLibRef
@@ -125,7 +125,7 @@ data TyLibRef         : primitive Primitive
 -- urn:ubideco:semid:5umsZQXgcipmGCn8h2TTged2CDuaSDoDJQzW3BkTr4aK#solo-canal-flower
 data TySemId          : primitive Primitive
                       | unicode ()
-                      | enum:3 EnumVariants
+                      | enum=3 EnumVariants
                       | union UnionVariantsSemId
                       | tuple UnnamedFieldsSemId
                       | struct NamedFieldsSemId

--- a/tests/byte_str.rs
+++ b/tests/byte_str.rs
@@ -42,7 +42,7 @@ fn reflect() {
 
 -- no dependencies
 
-data ByteStr          :: [Byte]
+data ByteStr          : [Byte]
 "
     );
 }


### PR DESCRIPTION
1. Use more compact Base85 instead of Base64 for text armoring
2. Use single colon `:` instead of double colon `::` for type definitions (Idris-style instead of Haskell-style). Rationale: type definitions are functions (type constructors)
3. Use equal sign for union/enum tags instead of colon (because of the above)