### PR TITLE
Fix struct encoding to match fields by name instead of position

### DIFF
--- a/src/value/encode.rs
+++ b/src/value/encode.rs
@@ -154,8 +154,16 @@ impl TypeSystem {
             }
             (StrictVal::Struct(vals), Ty::Struct(fields)) => {
                 debug_assert_eq!(vals.len(), fields.len());
-                for (val, field) in vals.values().zip(fields) {
-                    self.strict_write_val(val, field.ty, writer)?;
+
+                for field in fields {
+                    let fname = &field.name;
+                    let Some(item) = vals.get(fname) else {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("missing field: {fname}"),
+                        ));
+                    };
+                    self.strict_write_val(item, field.ty, writer)?;
                 }
             }
             (StrictVal::Enum(EnumTag::Ord(tag)), Ty::Enum(variants)) => {


### PR DESCRIPTION
## Description

This PR fixes encoding errors when field orders don't match between values and types.

### Problem

After addressing previous RGB21 issuance issues, a new error appeared:

```
bug in business logic of type system. Details:
Number(
Uint(
10000,
),
)
Array(
SemId(
Array<32>(1cabbfc3d826c0bfd1e9770a889efacc8b6716ad014a3eec10b6591530229042),
),
26,
)
```

### Root Cause

The `strict_write_ty` method in `src/value/encode.rs` assumes that value fields and type fields appear in the same order, but they can differ in practice. The current implementation uses position-based matching:
```rust
(StrictVal::Struct(vals), Ty::Struct(fields)) => {
    debug_assert_eq!(vals.len(), fields.len());
    for (val, field) in vals.values().zip(fields) {
        self.strict_write_val(val, field.ty, writer)?;
    }
}
```

### Solution

Modified the struct encoding to match fields by name rather than by position:
```rust
for (fname, item) in vals.into_iter() {
    let Some(field) = fields.ty_by_name(&fname) else {
        return Err(io::Error::new(
            io::ErrorKind::InvalidData,
            format!("extra field: {fname}"),
        ));
    };
    self.strict_write_val(item, *field, writer)?;
}
```

### Related Issues

Part of the fix for [Addressing type resolution in RGB21 asset issuance process](https://github.com/pandora-prime/rgb-issuers/issues/2)

### Testing

Successfully tested with FAC asset issuance after applying all related fixes.