### PR TITLE
add tests showing type lib inconsistency

### DIFF
--- a/tests/dependencies.rs
+++ b/tests/dependencies.rs
@@ -27,11 +27,13 @@ extern crate strict_types;
 
 use std::io;
 
+use strict_encoding::stl::{AlphaLodash, Bool};
 use strict_encoding::{
-    DecodeError, StrictDecode, StrictEncode, StrictType, TypedRead, TypedWrite, STRICT_TYPES_LIB,
+    DecodeError, Ident, StrictDecode, StrictDumb, StrictEncode, StrictType, TypedRead, TypedWrite,
+    LIB_NAME_STD, STRICT_TYPES_LIB,
 };
-use strict_types::stl::std_stl;
-use strict_types::{Dependency, LibBuilder, TypeLib};
+use strict_types::stl::{std_stl, strict_types_stl};
+use strict_types::{Dependency, LibBuilder, SystemBuilder, TypeLib};
 
 const LIB: &str = "Test";
 
@@ -114,4 +116,119 @@ fn serialize() {
     let lib = builder.compile_symbols().unwrap();
 
     println!("{}", lib);
+}
+
+#[test]
+fn type_lib_missing_type() {
+    // construct the original SymbolicSys
+    let libs_orig = [strict_types_stl(), std_stl()];
+    let mut builder_orig = SystemBuilder::new();
+    for lib in libs_orig.into_iter() {
+        builder_orig = builder_orig.import(lib).unwrap();
+    }
+    let sys_orig = builder_orig.finalize().unwrap();
+
+    // construct a copy of std_stl that uses only Bool
+    let std_stl_mod = LibBuilder::new(libname!(LIB_NAME_STD), None)
+        .transpile::<Bool>()
+        .compile_symbols()
+        .unwrap()
+        .compile()
+        .unwrap();
+
+    // construct a library that uses the original Ident but depends on the modified std_stl
+    let strict_types_stl_mod =
+        LibBuilder::new(libname!(STRICT_TYPES_LIB), [std_stl_mod.to_dependency()])
+            .transpile::<Ident>()
+            .compile_symbols()
+            .unwrap()
+            .compile()
+            .unwrap();
+
+    // construct a modified SymbolicSys
+    let libs_mod = [strict_types_stl_mod, std_stl_mod];
+    let mut builder_mod = SystemBuilder::new();
+    for lib in libs_mod.into_iter() {
+        builder_mod = builder_mod.import(lib).unwrap();
+    }
+    let sys_mod = builder_mod.finalize().unwrap();
+
+    // get the sem ID for AlphaLodash from the modified SymbolicSys
+    let alphalodash_semid_orig = sys_orig.resolve("Std.AlphaLodash").unwrap();
+
+    // getting the AlphaLodash type from the original TypeSystem succeeds, as expected
+    sys_orig.clone().into_type_system().find(*alphalodash_semid_orig).unwrap();
+    // getting the AlphaLodash type from the modified TypeSystem fails
+    sys_mod.clone().into_type_system().find(*alphalodash_semid_orig).unwrap();
+}
+
+#[test]
+fn type_lib_semid_inconsistency() {
+    // construct the original SymbolicSys
+    let libs_orig = [strict_types_stl(), std_stl()];
+    let mut builder_orig = SystemBuilder::new();
+    for lib in libs_orig.into_iter() {
+        builder_orig = builder_orig.import(lib).unwrap();
+    }
+    let sys_orig = builder_orig.finalize().unwrap();
+
+    // define a modified AlphaNumLodash
+    #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
+    #[derive(StrictDumb, StrictType, StrictEncode, StrictDecode)]
+    #[strict_type(lib = LIB_NAME_STD, tags = repr, into_u8, try_from_u8)]
+    #[display(inner)]
+    #[repr(u8)]
+    pub enum AlphaNumLodash {
+        #[strict_type(dumb)]
+        #[display("0")]
+        Zero = b'0',
+    }
+
+    // construct a copy of std_stl that uses the modified AlphaNumLodash
+    let std_stl_mod = LibBuilder::new(libname!(LIB_NAME_STD), None)
+        .transpile::<AlphaLodash>()
+        .transpile::<AlphaNumLodash>()
+        .compile_symbols()
+        .unwrap()
+        .compile()
+        .unwrap();
+
+    // construct a library that uses the original Ident but depends on the modified std_stl
+    let strict_types_stl_mod =
+        LibBuilder::new(libname!(STRICT_TYPES_LIB), [std_stl_mod.to_dependency()])
+            .transpile::<Ident>()
+            .compile_symbols()
+            .unwrap()
+            .compile()
+            .unwrap();
+
+    // construct a modified SymbolicSys
+    let libs_mod = [strict_types_stl_mod, std_stl_mod];
+    let mut builder_mod = SystemBuilder::new();
+    for lib in libs_mod.into_iter() {
+        builder_mod = builder_mod.import(lib).unwrap();
+    }
+    let sys_mod = builder_mod.finalize().unwrap();
+
+    // get the sem IDs for Ident and related types from the original SymbolicSys
+    let ident_semid_orig = sys_orig.resolve("StrictTypes.Ident").unwrap();
+    let alphalodash_semid_orig = sys_orig.resolve("Std.AlphaLodash").unwrap();
+    let alphanumlodash_semid_orig = sys_orig.resolve("Std.AlphaNumLodash").unwrap();
+
+    // get the sem IDs for Ident and related types from the modified SymbolicSys
+    let ident_semid_mod = sys_mod.resolve("StrictTypes.Ident").unwrap();
+    let alphalodash_semid_mod = sys_mod.resolve("Std.AlphaLodash").unwrap();
+    let alphanumlodash_semid_mod = sys_mod.resolve("Std.AlphaNumLodash").unwrap();
+
+    // check that Ident and related types are available in the modified TypeSystem
+    sys_mod.clone().into_type_system().find(*ident_semid_mod).unwrap();
+    sys_mod.clone().into_type_system().find(*alphalodash_semid_mod).unwrap();
+    sys_mod.clone().into_type_system().find(*alphanumlodash_semid_mod).unwrap();
+
+    // AlphaLodash sem IDs from the 2 SymbolicSys match, as expected
+    assert_eq!(alphalodash_semid_orig, alphalodash_semid_mod);
+    // AlphaNumLodash sem IDs from the 2 SymbolicSys differ, as expected
+    assert_ne!(alphanumlodash_semid_orig, alphanumlodash_semid_mod);
+    // Ident sem IDs from the 2 SymbolicSys unexpectedly match
+    assert_ne!(ident_semid_orig, ident_semid_mod); // fails
 }


### PR DESCRIPTION
This PR adds two tests to showcase an inconsistency:

- `type_lib_missing_type`: shows that a type can be built even if one of its dependencies is actually missing from the type libs (not transpiled)
- `type_lib_semid_inconsistency`: shows that a higher-level type sem ID isn't influenced by a change in a lower-level type (transpiled in the type lib)

In both cases, the unexpected behavior comes from the fact that type sem IDs come from the actual Rust objects, regardless of the transpiled types, and the match between the two is not checked.